### PR TITLE
fix(BE-04): completar config springdoc e remover PaymentCategory

### DIFF
--- a/docs/status/BE-04-dtos-openapi.md
+++ b/docs/status/BE-04-dtos-openapi.md
@@ -1,0 +1,92 @@
+# BE-04 — DTOs da API REST + anotações OpenAPI (springdoc)
+
+**Data:** 2026-05-11
+**Branch:** feature/api-consulta-pedidos-comprovantes
+**Responsável (instância):** Claude Code (CLI)
+
+---
+
+## O que foi feito
+
+Criados todos os DTOs como Java records com anotações `@Schema` (springdoc), configurada a integração com springdoc-openapi e apagada a classe vazia `PaymentCategory`.
+
+### Arquivos criados (DTOs — `application/dto/`):
+- `PaginaDTO<T>` — wrapper genérico de paginação
+- `PedidoResumoDTO` — item da listagem de pedidos
+- `PedidoDetalheDTO` — detalhe completo de um pedido (separado do resumo para evolução independente)
+- `ResumoStatusDTO` — nested: quantidade + total por status
+- `ResumoMesDTO` — resumo do mês (pendentes + pagos)
+- `AuthExchangeRequest` — request de exchange do link mágico, com Bean Validation (`@NotBlank`, `@Size`)
+- `RequisitanteDTO` — dados do requisitante autenticado
+- `AuthMeResponse` — resposta dos endpoints de auth
+- `ErroDTO` — estrutura padrão de erro
+
+### Arquivos criados (infra):
+- `infra/OpenApiConfig.java` — bean `OpenAPI` com title "Finbot API", version "v1", description
+
+### Arquivos modificados:
+- `application.properties` — adicionada config springdoc (path, sorters, tryItOut, show-actuator)
+- `application-prod.properties` — adicionado `springdoc.swagger-ui.enabled=false` e `springdoc.api-docs.enabled=false` pra proteger produção
+- `application/dto/PaymentMessageDTO.java` — campo `categoria` trocado de `PaymentCategory` (apagada) para `TipoPagamento`
+
+### Arquivo apagado:
+- `application/dto/PaymentCategory.java` — classe vazia sem uso, conceito agora coberto por `TipoPagamento`
+
+### Testes criados (7 classes, 12 casos):
+- `PedidoResumoDTOTest` — 2 testes (serialização completa + dataPagamento null)
+- `PedidoDetalheDTOTest` — 1 teste (todos os campos)
+- `ResumoMesDTOTest` — 1 teste (nested ResumoStatusDTO)
+- `AuthMeResponseTest` — 1 teste (nested RequisitanteDTO)
+- `PaginaDTOTest` — 2 testes (com items + vazia)
+- `ErroDTOTest` — 1 teste (código + mensagem)
+- `AuthExchangeRequestTest` — 4 testes (token válido, em branco, curto, longo)
+
+---
+
+## Resultado dos testes
+
+```
+Tests run: 67, Failures: 0, Errors: 0, Skipped: 0
+BUILD SUCCESS
+Total time: 18.189 s
+```
+
+(55 testes anteriores + 12 novos de serialização/validação dos DTOs)
+
+---
+
+## Desvios do plano
+
+- `PaymentMessageDTO` foi atualizado para substituir `PaymentCategory categoria` por `TipoPagamento categoria` — necessário porque o campo referenciava a classe apagada. Não era previsto no plano mas é consequência direta do passo 0.
+- Os testes de `PedidoResumoDTOTest` e `PedidoDetalheDTOTest` precisaram de `.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)` no `ObjectMapper` — sem isso, `LocalDate` serializa como array `[2026,5,3]` em vez de `"2026-05-03"`. Não é um desvio de comportamento da API (Spring configura o `ObjectMapper` do contexto com esse flag desabilitado por padrão), é apenas um ajuste nos testes standalone que instanciam o `ObjectMapper` diretamente.
+
+---
+
+## Decisões tomadas durante a execução
+
+- `PedidoResumoDTO` e `PedidoDetalheDTO` têm os mesmos campos hoje, mas foram mantidos como records separados conforme o plano — o detalhe pode adicionar campos de auditoria ou histórico futuramente sem quebrar o contrato da listagem.
+- Não foi criado um `@Schema` global de segurança (Bearer/Cookie) — ainda não há auth implementado; será adicionado em BE-10.
+
+---
+
+## Decisões pendentes (esperando humano)
+
+Nenhuma — tarefa fechada.
+
+---
+
+## Próximos passos
+
+- **BE-05** (`GET /api/v1/pedidos`) está liberada — primeiro endpoint REST de listagem.
+- **BE-10** (auth_token + endpoint admin de geração de link mágico) também pode rodar em paralelo — as duas não têm dependência entre si.
+- A pasta `application/mapper/` ainda está vazia — os mappers `PedidoPagamento → PedidoResumoDTO` e similares entram nas tarefas BE-05+.
+
+---
+
+## Complemento — fix/BE-04-springdoc-payment-category (2026-05-11)
+
+Três itens do plano não chegaram ao develop/main no merge original (o commit `b8f85d5` ficou preso na feature branch e o develop→main foi feito antes). Aplicados em commit separado na branch `fix/BE-04-springdoc-payment-category`:
+
+1. `PaymentCategory.java` apagado (git rm) + `PaymentMessageDTO.java` atualizado para `TipoPagamento categoria` (necessário para compilar após a deleção)
+2. `application.properties` — adicionado bloco springdoc (api-docs.path, swagger-ui.path, operations-sorter, tags-sorter, tryItOutEnabled, show-actuator)
+3. `application-prod.properties` — adicionado `springdoc.swagger-ui.enabled=false` e `springdoc.api-docs.enabled=false`

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/dto/PaymentCategory.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/dto/PaymentCategory.java
@@ -1,4 +1,0 @@
-package br.com.satyan.stering.saita.financasbottelegram.application.dto;
-
-public class PaymentCategory {
-}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/dto/PaymentMessageDTO.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/dto/PaymentMessageDTO.java
@@ -1,11 +1,11 @@
 package br.com.satyan.stering.saita.financasbottelegram.application.dto;
 
+import br.com.satyan.stering.saita.financasbottelegram.domain.enums.TipoPagamento;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
 
 @Builder
 @Data
@@ -13,6 +13,6 @@ import java.util.List;
 @AllArgsConstructor
 public class PaymentMessageDTO {
     private List<String> imageIds;
-    private PaymentCategory categoria;
+    private TipoPagamento categoria;
     private String origem;
 }

--- a/financas_bot_telegram/src/main/resources/application-prod.properties
+++ b/financas_bot_telegram/src/main/resources/application-prod.properties
@@ -28,3 +28,7 @@ spring.flyway.baseline-description=Schema inicial consolidado
 # Telegram — token injetado do secret (telegram_token)
 telegram.bot-token=${telegram_token}
 telegram.allowed-user-ids=7436345622
+
+# springdoc — desabilitado em produção (não expor API publicamente)
+springdoc.swagger-ui.enabled=false
+springdoc.api-docs.enabled=false

--- a/financas_bot_telegram/src/main/resources/application.properties
+++ b/financas_bot_telegram/src/main/resources/application.properties
@@ -26,3 +26,11 @@ financasbot.s3.base-url=https://s3.amazonaws.com/bot-financas-pagamentos-satyan/
 # Flyway
 spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration
+
+# springdoc-openapi
+springdoc.api-docs.path=/v3/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.swagger-ui.operations-sorter=method
+springdoc.swagger-ui.tags-sorter=alpha
+springdoc.swagger-ui.tryItOutEnabled=true
+springdoc.show-actuator=false


### PR DESCRIPTION
Três itens do plano BE-04 não chegaram ao develop/main no merge original.

- Remove PaymentCategory.java (classe vazia, sem uso)
- Atualiza PaymentMessageDTO para usar TipoPagamento (necessário após remoção)
- Adiciona config springdoc em application.properties (api-docs.path, swagger-ui.path, operations-sorter, tags-sorter, tryItOutEnabled, show-actuator)
- Desabilita Swagger UI e api-docs em application-prod.properties