### PR TITLE
feat(BE-16): resumo com filtros mes/busca + pastas S3 separadas

### DIFF
--- a/docs/avaliacoes/backend-be-16.md
+++ b/docs/avaliacoes/backend-be-16.md
@@ -1,0 +1,101 @@
+# Avaliação — BE-16 (resumo parametrizado + pastas S3)
+
+**Branch:** `feature/be-16-resumo-e-pastas-s3`
+**Tarefas:** Task 1 (resumo aceita mês + busca, campo `todos`) · Task 2 (separar pastas S3)
+**Implementador:** Claude do back
+**Avaliado por:** humano (validação manual) + Claude de planejamento (análise de código)
+**Data:** 2026-05-19
+
+---
+
+## Análise de código (planejamento)
+
+### Veredito: aprovado com 2 observações
+
+**Task 1 — Resumo.** Implementação limpa. `ResumoController` valida `mes` e lança `MesFormatoInvalidoException` (→ 400). `ResumoMesServiceImpl` usa `Clock` (testável), default = mês corrente, ramifica por busca, monta `todos = pendentes + pagos`. DTO renomeou `mesAtual→mes` e adicionou `todos`. Query agrega via `GROUP BY status` com `COALESCE(SUM, 0)`.
+
+**Task 2 — S3.** `TipoUploadS3` (PEDIDO/COMPROVANTE) limpo. `uploadFile(bytes, extensao, tipoUpload)` parametriza folder + extensão; `uploadImage` legado delega pra `PEDIDO`. Strategies passam o enum certo.
+
+### Observação 1 — branch contém EVO-07 (atenção no merge)
+
+As strategies importam `TipoArquivo` / `TipoArquivoNaoSuportadoException` e tratam document/PDF — isso é da EVO-07. Logo, esta branch foi baseada na `polish-evo07` (ou a polish-evo07 já entrou na develop). **Consequência boa:** o conflito S3 que o plano antecipava já está resolvido (assinatura `uploadFile` combina `extensao` da EVO-07 + `TipoUploadS3` da BE-16). **Atenção:** confirmar a ordem de merge — se polish-evo07 ainda não está na develop, mergear ela antes (ou o PR da BE-16 já carrega a EVO-07 junto, o que precisa ser intencional).
+
+### Observação 2 — `todos` exclui CANCELADO (inconsistência latente)
+
+`StatusPedido` tem 3 valores (PENDENTE, PAGO, CANCELADO). A query do resumo agrupa por **todos** os status, mas o service só extrai PENDENTE e PAGO; `todos = pendentes + pagos`. Um pedido CANCELADO é silenciosamente descartado de todos os contadores.
+
+Hoje não há fluxo de cancelamento, então é **latente, não bug ativo**. Mas: o front (FE-12) vai usar `resumo.todos.quantidade` como contador "Tudo". Se a listagem (`GET /api/v1/pedidos?status=todos`) algum dia incluir cancelados e o resumo não, recriamos a inconsistência que a BE-16 veio consertar. Recomendação: decidir e documentar que CANCELADO é excluído em todo lugar (resumo + listagem), ou alinhar quando o cancelamento existir. Teste 1.10 abaixo cobre essa checagem.
+
+---
+
+## Roteiro de validação manual
+
+Ambiente dev rodando (`mvn spring-boot:run -Dspring-boot.run.profiles=dev`). Para Task 1, estar autenticado (JWT válido via fluxo magic link → `/auth/exchange`, ou autorizar no Swagger). Para Task 2, bot de dev ativo + acesso ao bucket S3 dev. Preencha **Resultado** com ✅/❌/⚠️.
+
+### Pré-condições
+
+- [ ] App dev subiu sem erro (BE-16 não adiciona migration — nada novo de schema)
+- [ ] Você tem pelo menos um mês com pedidos de status variados no banco dev (ideal: um mês com PENDENTE + PAGO)
+
+---
+
+### Task 1 — Resumo parametrizado (via Swagger ou curl autenticado)
+
+| # | Ação | Esperado | Resultado | Observação |
+|---|---|---|-----------|---|
+| 1.1 | `GET /api/v1/resumo` sem params | 200 com `mes` (mês corrente), `todos`, `pendentes`, `pagos`, cada um com `quantidade` e `total` | OK        | |
+| 1.2 | `GET /api/v1/resumo?mes=2026-04` (um mês que tem pedidos) | 200, dados referentes a abril | OK        | |
+| 1.3 | `GET /api/v1/resumo?mes=2026-05` | 200, dados de maio — diferentes de 1.2 | OK        | |
+| 1.4 | `GET /api/v1/resumo?busca=<texto que existe>` (ex: `energia`) | 200, contadores refletem só pedidos cuja descrição contém o texto | OK        | |
+| 1.5 | `GET /api/v1/resumo?mes=2026-04&busca=<texto>` | 200, combina mês + busca | OK        | |
+| 1.6 | `GET /api/v1/resumo?mes=2026-13` (mês inválido) | 400 com código `MES_INVALIDO` (ou estrutura de erro padrão) | OK        | |
+| 1.7 | `GET /api/v1/resumo?mes=abc` (formato inválido) | 400 | OK        | |
+| 1.8 | Em qualquer resposta 200, conferir a invariante | `todos.quantidade == pendentes.quantidade + pagos.quantidade` e `todos.total == pendentes.total + pagos.total` | OK        | |
+| 1.9 | Inspecionar o JSON | Campo se chama `mes` (não mais `mesAtual`) | OK        | |
+| 1.10 | **Consistência com a listagem:** comparar `resumo.todos.quantidade` (de `?mes=X`) com o `total` de `GET /api/v1/pedidos?de=X-01&ate=X-31&status=todos` | Os dois números batem. Se divergirem, investigar CANCELADO (ver Observação 2) | OK        | |
+| 1.11 | `GET /api/v1/resumo` **sem** JWT | 401 ou 403 (não 200) | OK        | |
+
+---
+
+### Task 2 — Pastas S3 separadas (via bot Telegram + console S3)
+
+| # | Ação | Esperado | Resultado | Observação                                         |
+|---|---|---|-----------|----------------------------------------------------|
+| 2.1 | Enviar **foto** com legenda de pedido (ex: `100 boleto Energia`) | Bot confirma pedido. No bucket S3, arquivo aparece em `pedidos/YYYYMMDD/<uuid>.jpg` | OK        |                                                    |
+| 2.2 | Enviar **foto** de comprovante (ex: `#<id_pendente> pix`) | Bot confirma comprovante. No bucket, arquivo aparece em `comprovantes/YYYYMMDD/<uuid>.jpg` | OK        |                                                    |
+| 2.3 | Enviar **PDF como arquivo** com legenda de pedido (ex: `200 ted João`) | Arquivo em `pedidos/YYYYMMDD/<uuid>.pdf` (extensão correta) |           | Nao executado                                                     |
+| 2.4 | Enviar **PDF como arquivo** de comprovante (ex: `#<id_pendente> boleto`) | Arquivo em `comprovantes/YYYYMMDD/<uuid>.pdf` |           | Nao executado                                      |
+| 2.5 | Abrir o front (ou a URL direta) de um comprovante **antigo** (salvo antes da BE-16, sob `pedidos/`) | Continua carregando normalmente — URLs antigas não quebraram |           | Front ainda nao esta testavel integrado com o back |
+
+---
+
+## Cobertura automatizada (referência — não precisa validar manual)
+
+Conforme relatório `docs/status/BE-16.md`: 226 testes, `BUILD SUCCESS`. Cobrem:
+- `ResumoMesServiceImplTest` (9 casos: com/sem mês, com/sem busca, zeros)
+- `ResumoControllerTest` (6 casos: validação 400, passagem de params)
+- `S3ImageUploadServiceTest` (7 casos: prefixos corretos, chaves únicas, erro S3)
+- `ResumoIntegrationTest` (5 casos: Testcontainers, busca, 400, 401)
+- `PaymentRequestStrategyTest` / `PaymentProofStrategyTest` (verificam enum correto)
+
+**Recomendado:** rodar `mvn clean verify` localmente e confirmar verde antes do merge.
+
+---
+
+## Resultado consolidado (preencher após os testes)
+
+| Item | Resultado | Observações |
+|---|---|---|
+| Task 1 — resumo parametrizado | | |
+| Task 2 — pastas S3 | | |
+| `mvn clean verify` | | |
+| **Recomendação geral** | mergear / ajustar / bloquear | |
+
+---
+
+## Para o Claude de planejamento (pós-validação)
+
+Após preencher, decidir:
+- Ordem de merge considerando que a branch carrega EVO-07 (Observação 1)
+- Se trata a Observação 2 (CANCELADO) agora ou registra como pendência técnica
+- Sincronizar o front (FE-12) quanto ao rename `mesAtual → mes`

--- a/docs/status/BE-16.md
+++ b/docs/status/BE-16.md
@@ -1,0 +1,56 @@
+---
+task: BE-16
+title: Resumo com mês/busca + pastas S3 separadas
+branch: feature/be-16-resumo-e-pastas-s3
+status: CONCLUÍDO
+data: 2026-05-19
+---
+
+## O que foi feito
+
+### Tarefa 1 — Resumo parametrizado
+
+- `GET /api/v1/resumo` agora aceita `?mes=YYYY-MM` e `?busca=texto`
+- Campo `mes` (antes `mesAtual`) no DTO de resposta
+- Campo `todos` adicionado (contagem e soma de PENDENTE + PAGO, excluindo CANCELADO)
+- Mês inválido retorna 400 com código `MES_INVALIDO`
+- Sem parâmetro `mes`, usa o mês corrente (comportamento anterior preservado)
+
+Arquivos alterados:
+- `domain/exceptions/MesFormatoInvalidoException.java` ← novo
+- `application/dto/ResumoMesDTO.java` ← renomeia `mesAtual→mes`, adiciona `todos`
+- `application/usecases/ResumoMesUseCase.java` ← novo signature `obter(id, ym, busca)`
+- `application/services/ResumoMesServiceImpl.java` ← lógica de busca e todos
+- `adapters/out/persistence/PedidoPagamentoJpaRepository.java` ← nova query com LIKE
+- `adapters/in/rest/resumo/ResumoController.java` ← `@RequestParam` mes e busca
+- `adapters/in/rest/RestExceptionHandler.java` ← handler MesFormatoInvalidoException
+
+### Tarefa 2 — Pastas S3 separadas
+
+- Novo enum `TipoUploadS3` com `PEDIDO("pedidos")` e `COMPROVANTE("comprovantes")`
+- `S3ImageUploadService.uploadFile()` agora recebe `TipoUploadS3` como terceiro argumento
+- `PaymentRequestStrategy` usa `TipoUploadS3.PEDIDO`
+- `PaymentProofStrategy` usa `TipoUploadS3.COMPROVANTE`
+- Backward-compat: `uploadImage()` delega para `uploadFile(..., TipoUploadS3.PEDIDO)`
+
+Arquivos alterados:
+- `domain/enums/TipoUploadS3.java` ← novo
+- `adapters/out/s3/service/S3ImageUploadService.java`
+- `adapters/in/telegram/strategy/PaymentRequestStrategy.java`
+- `adapters/in/telegram/strategy/PaymentProofStrategy.java`
+
+## Testes
+
+- Todos os testes existentes atualizados para os novos contratos
+- Novos testes adicionados:
+  - `ResumoMesServiceImplTest` — 9 casos (com/sem mês, com/sem busca, zeros)
+  - `ResumoControllerTest` — 6 casos (400 validação, passagem de params)
+  - `S3ImageUploadServiceTest` — 7 casos (prefixos corretos, chaves únicas, S3 erro)
+  - `ResumoIntegrationTest` — 5 casos (Testcontainers, busca, 400, 401)
+  - `PaymentRequestStrategyTest` — verifica `TipoUploadS3.PEDIDO`
+  - `PaymentProofStrategyTest` — verifica `TipoUploadS3.COMPROVANTE`
+- Build: `BUILD SUCCESS`, 226 testes passando
+
+## Impacto no frontend
+
+O campo `mesAtual` foi renomeado para `mes` no payload JSON. O frontend (FE-12) precisa atualizar o tipo `ResumoMesDTO` e qualquer referência a esse campo.

--- a/financas_bot_telegram/http/BE-16-testes.http
+++ b/financas_bot_telegram/http/BE-16-testes.http
@@ -1,0 +1,110 @@
+# BE-16 — Roteiro de validação manual
+# Task 1: Resumo parametrizado (cenários 1.1–1.11)
+#
+# Como usar:
+#   1. Selecione o environment "dev" no canto superior direito do IntelliJ
+#   2. Siga os passos de autenticação abaixo (0 → 1)
+#   3. O cookie finbot_session é armazenado automaticamente — pode rodar os testes em sequência
+#
+# Task 2 (S3) não tem requests HTTP — é manual via Telegram + console S3.
+
+### ============================================================
+### AUTENTICAÇÃO
+### ============================================================
+
+### Passo 0 — Gerar magic link (dev admin)
+# Retorna: {"url": "http://localhost:5173/auth?token=..."}
+# Copie o valor de "token" da URL e cole em {{TOKEN}} no Passo 1
+POST {{base_url}}/admin/api/v1/requisitantes/{{requisitante_id}}/convite
+X-Admin-Key: {{admin_key}}
+
+###
+
+### Passo 1 — Trocar token por sessão
+# Substitua TOKEN_AQUI pelo valor copiado no Passo 0
+# Após executar: o cookie finbot_session fica salvo — todos os requests abaixo já estarão autenticados
+POST {{base_url}}/api/v1/auth/exchange
+Content-Type: application/json
+
+{
+  "token": "cbiRX4DxfSqGV8l3R0W8EM9AIadicQt8Q_8vvgfhIFA"
+}
+
+###
+
+### Verificação — Confirmar sessão ativa
+GET {{base_url}}/api/v1/auth/me
+
+### ============================================================
+### TASK 1 — RESUMO PARAMETRIZADO
+### ============================================================
+
+### 1.1 — Sem params (mês corrente)
+# Esperado: 200 com campo "mes" = mês atual, + todos/pendentes/pagos com quantidade e total
+GET {{base_url}}/api/v1/resumo
+
+###
+
+### 1.2 — Mês específico com dados (abril)
+# Esperado: 200 com dados referentes a 2026-04
+GET {{base_url}}/api/v1/resumo?mes={{mes_com_dados}}
+
+###
+
+### 1.3 — Mês de maio (deve diferir de 1.2)
+# Esperado: 200 com dados de 2026-05
+GET {{base_url}}/api/v1/resumo?mes={{mes_atual}}
+
+###
+
+### 1.4 — Busca textual
+# Esperado: 200 com contadores refletindo apenas pedidos cuja descrição contém "{{busca_texto}}"
+# Ajuste o valor de busca_texto no http-client.env.json conforme o que existe no seu banco
+GET {{base_url}}/api/v1/resumo?busca={{busca_texto}}
+
+###
+
+### 1.5 — Mês + busca combinados
+# Esperado: 200 combinando filtro de mês e de texto
+GET {{base_url}}/api/v1/resumo?mes={{mes_com_dados}}&busca={{busca_texto}}
+
+###
+
+### 1.6 — Mês inválido (mês 13 não existe)
+# Esperado: 400 com erro estruturado (código MES_INVALIDO ou similar)
+GET {{base_url}}/api/v1/resumo?mes=2026-13
+
+###
+
+### 1.7 — Formato de mês inválido
+# Esperado: 400
+GET {{base_url}}/api/v1/resumo?mes=abc
+
+###
+
+### 1.8 / 1.9 — Invariante e nome do campo
+# Verificar manualmente na resposta:
+#   - Campo se chama "mes" (não "mesAtual")
+#   - todos.quantidade == pendentes.quantidade + pagos.quantidade
+#   - todos.total == pendentes.total + pagos.total
+GET {{base_url}}/api/v1/resumo?mes={{mes_atual}}
+
+###
+
+### 1.10a — Listagem do mês (para comparação com resumo)
+# Anote o campo "total" da resposta (total de pedidos sem filtro de status)
+GET {{base_url}}/api/v1/pedidos?de={{mes_atual}}-01&ate={{mes_atual}}-31
+
+###
+
+### 1.10b — Resumo do mesmo mês (comparar com 1.10a)
+# Verificar: resumo.todos.quantidade == listagem.total de 1.10a
+# Se divergirem, investigar pedidos CANCELADO (ver Observação 2 da avaliação)
+GET {{base_url}}/api/v1/resumo?mes={{mes_atual}}
+
+###
+
+### 1.11 — Sem autenticação (cookie ignorado nesta request)
+# Esperado: 401 ou 403
+# @no-cookie-jar
+GET {{base_url}}/api/v1/resumo

--- a/financas_bot_telegram/http/http-client.env.json
+++ b/financas_bot_telegram/http/http-client.env.json
@@ -1,0 +1,10 @@
+{
+  "dev": {
+    "base_url": "http://localhost:8080",
+    "admin_key": "UJIL3/O6yVw8gHQt3kFdiVqrcAkVAs3xr0ybGmTEj/k=",
+    "mes_com_dados": "2026-04",
+    "mes_atual": "2026-05",
+    "busca_texto": "pagamento",
+    "requisitante_id": "1"
+  }
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/rest/RestExceptionHandler.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/rest/RestExceptionHandler.java
@@ -4,6 +4,7 @@ import br.com.satyan.stering.saita.financasbottelegram.application.dto.ErroDTO;
 import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.AuthTokenInvalidoException;
 import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.ComprovanteNaoEncontradoException;
 import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.ImagemNaoEncontradaException;
+import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.MesFormatoInvalidoException;
 import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.PedidoNaoAutorizadoException;
 import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.PedidoNaoEncontradoException;
 import java.util.stream.Collectors;
@@ -43,6 +44,12 @@ public class RestExceptionHandler {
     public ResponseEntity<ErroDTO> handleComprovanteNaoEncontrado(ComprovanteNaoEncontradoException e) {
         return ResponseEntity.status(404)
                 .body(new ErroDTO("COMPROVANTE_NAO_ENCONTRADO", e.getMessage()));
+    }
+
+    @ExceptionHandler(MesFormatoInvalidoException.class)
+    public ResponseEntity<ErroDTO> handleMesFormatoInvalido(MesFormatoInvalidoException e) {
+        return ResponseEntity.badRequest()
+                .body(new ErroDTO("MES_INVALIDO", e.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/rest/resumo/ResumoController.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/rest/resumo/ResumoController.java
@@ -2,10 +2,15 @@ package br.com.satyan.stering.saita.financasbottelegram.adapters.in.rest.resumo;
 
 import br.com.satyan.stering.saita.financasbottelegram.application.dto.ResumoMesDTO;
 import br.com.satyan.stering.saita.financasbottelegram.application.usecases.ResumoMesUseCase;
+import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.MesFormatoInvalidoException;
 import br.com.satyan.stering.saita.financasbottelegram.infra.security.RequisitanteId;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import java.time.YearMonth;
+import java.time.format.DateTimeParseException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -19,8 +24,22 @@ public class ResumoController {
     }
 
     @GetMapping
-    @Operation(summary = "Resumo do mês corrente: pendentes + pagos")
-    public ResumoMesDTO obter(@RequisitanteId Long requisitanteId) {
-        return useCase.obter(requisitanteId);
+    @Operation(summary = "Resumo do mês: todos, pendentes e pagos — com filtros opcionais de mês e busca")
+    public ResumoMesDTO obter(
+            @RequisitanteId Long requisitanteId,
+            @Parameter(description = "Mês no formato YYYY-MM. Default: mês corrente.", example = "2026-05")
+            @RequestParam(required = false) String mes,
+            @Parameter(description = "Filtra por texto na descrição (contém, case-insensitive).", example = "boleto")
+            @RequestParam(required = false) String busca) {
+
+        YearMonth yearMonth = null;
+        if (mes != null && !mes.isBlank()) {
+            try {
+                yearMonth = YearMonth.parse(mes);
+            } catch (DateTimeParseException e) {
+                throw new MesFormatoInvalidoException(mes);
+            }
+        }
+        return useCase.obter(requisitanteId, yearMonth, busca);
     }
 }

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/telegram/strategy/PaymentProofStrategy.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/telegram/strategy/PaymentProofStrategy.java
@@ -8,6 +8,7 @@ import br.com.satyan.stering.saita.financasbottelegram.adapters.out.telegram.ser
 import br.com.satyan.stering.saita.financasbottelegram.adapters.out.telegram.service.TelegramMessageSenderService;
 import br.com.satyan.stering.saita.financasbottelegram.application.usecases.RegistrarComprovanteUsecase;
 import br.com.satyan.stering.saita.financasbottelegram.domain.enums.TipoArquivo;
+import br.com.satyan.stering.saita.financasbottelegram.domain.enums.TipoUploadS3;
 import br.com.satyan.stering.saita.financasbottelegram.domain.model.Comprovante;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,7 +87,7 @@ public class PaymentProofStrategy implements UpdateProcessingStrategy {
 
     byte[] bytes = telegramFileDownloaderService.downloadImageByFileId(extraido.fileId());
 
-    String s3Url = s3ImageUploadService.uploadFile(bytes, extraido.extensao());
+    String s3Url = s3ImageUploadService.uploadFile(bytes, extraido.extensao(), TipoUploadS3.COMPROVANTE);
     logger.info("Comprovante enviado para S3: {}", s3Url);
 
     Comprovante comprovanteSalvo = registrarComprovanteUsecase.execute(

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/telegram/strategy/PaymentRequestStrategy.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/telegram/strategy/PaymentRequestStrategy.java
@@ -10,6 +10,7 @@ import br.com.satyan.stering.saita.financasbottelegram.application.usecases.Salv
 import br.com.satyan.stering.saita.financasbottelegram.domain.enums.StatusPedido;
 import br.com.satyan.stering.saita.financasbottelegram.domain.enums.TipoArquivo;
 import br.com.satyan.stering.saita.financasbottelegram.domain.enums.TipoPagamento;
+import br.com.satyan.stering.saita.financasbottelegram.domain.enums.TipoUploadS3;
 import br.com.satyan.stering.saita.financasbottelegram.domain.model.PedidoPagamento;
 import br.com.satyan.stering.saita.financasbottelegram.domain.service.LegendaParser;
 import org.slf4j.Logger;
@@ -63,7 +64,7 @@ public class PaymentRequestStrategy implements UpdateProcessingStrategy {
 
     byte[] bytes = telegramFileDownloaderService.downloadImageByFileId(extraido.fileId());
 
-    String s3Url = s3ImageUploadService.uploadFile(bytes, extraido.extensao());
+    String s3Url = s3ImageUploadService.uploadFile(bytes, extraido.extensao(), TipoUploadS3.PEDIDO);
     logger.info("Imagem do pedido enviada para S3: {}", s3Url);
 
     PedidoPagamento pedido = parsePedido(message);

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/PedidoPagamentoJpaRepository.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/PedidoPagamentoJpaRepository.java
@@ -27,4 +27,20 @@ public interface PedidoPagamentoJpaRepository
             @Param("requisitanteId") Long requisitanteId,
             @Param("inicioMes") LocalDate inicioMes,
             @Param("fimMes") LocalDate fimMes);
+
+    @Query("""
+           SELECT new br.com.satyan.stering.saita.financasbottelegram.adapters.out.persistence.AgregadoStatus(
+               p.status, COUNT(p), COALESCE(SUM(p.valor), 0))
+           FROM PedidoPagamentoEntity p
+           WHERE p.requisitanteId = :requisitanteId
+             AND p.dataPedido >= :inicioMes
+             AND p.dataPedido <= :fimMes
+             AND LOWER(p.descricao) LIKE :buscaPattern
+           GROUP BY p.status
+           """)
+    List<AgregadoStatus> agregarPorStatusNoIntervaloComBusca(
+            @Param("requisitanteId") Long requisitanteId,
+            @Param("inicioMes") LocalDate inicioMes,
+            @Param("fimMes") LocalDate fimMes,
+            @Param("buscaPattern") String buscaPattern);
 }

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/s3/service/S3ImageUploadService.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/s3/service/S3ImageUploadService.java
@@ -1,64 +1,58 @@
 package br.com.satyan.stering.saita.financasbottelegram.adapters.out.s3.service;
 
+import br.com.satyan.stering.saita.financasbottelegram.domain.enums.TipoUploadS3;
 import io.awspring.cloud.s3.S3Template;
+import java.io.ByteArrayInputStream;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.io.ByteArrayInputStream;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.util.UUID;
-
-/**
- * Serviço responsável por fazer upload de imagens para o bucket S3.
- * Utiliza particionamento de pastas baseado em data: bucket/pedidos/YYYYMMDD/UUID.jpg
- */
 @Service
 public class S3ImageUploadService {
 
-  private static final Logger logger = LoggerFactory.getLogger(S3ImageUploadService.class);
-  private static final String FOLDER_PREFIX = "pedidos";
-  private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final Logger logger = LoggerFactory.getLogger(S3ImageUploadService.class);
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
 
-  private final S3Template s3Template;
-  private final String bucketName;
-  private final String baseUrl;
+    private final S3Template s3Template;
+    private final String bucketName;
+    private final String baseUrl;
 
-  public S3ImageUploadService(S3Template s3Template,
-      @Value("${aws.s3.bucket-name:bot-financas-pagamentos-satyan}") String bucketName,
-      @Value("${financasbot.s3.base-url:https://s3.amazonaws.com/bot-financas-pagamentos-satyan/}") String baseUrl) {
-    this.s3Template = s3Template;
-    this.bucketName = bucketName;
-    this.baseUrl = baseUrl;
-  }
-
-  public String uploadImage(byte[] imageBytes) {
-    return uploadFile(imageBytes, "jpg");
-  }
-
-  public String uploadFile(byte[] bytes, String extension) {
-    try {
-      String key = construirChaveS3(extension);
-      logger.info("Iniciando upload para S3 com chave: {}", key);
-      s3Template.upload(bucketName, key, new ByteArrayInputStream(bytes));
-      String url = buildImageUrl(key);
-      logger.info("Arquivo enviado para S3. URL: {}", url);
-      return url;
-    } catch (Exception e) {
-      logger.error("Erro ao fazer upload do arquivo para S3", e);
-      throw new S3UploadException("Falha ao salvar arquivo no S3: " + e.getMessage(), e);
+    public S3ImageUploadService(S3Template s3Template,
+            @Value("${aws.s3.bucket-name:bot-financas-pagamentos-satyan}") String bucketName,
+            @Value("${financasbot.s3.base-url:https://s3.amazonaws.com/bot-financas-pagamentos-satyan/}") String baseUrl) {
+        this.s3Template = s3Template;
+        this.bucketName = bucketName;
+        this.baseUrl = baseUrl;
     }
-  }
 
-  private String construirChaveS3(String extension) {
-    String today = LocalDate.now().format(DATE_FORMATTER);
-    return String.format("%s/%s/%s.%s", FOLDER_PREFIX, today, UUID.randomUUID(), extension);
-  }
+    public String uploadImage(byte[] imageBytes) {
+        return uploadFile(imageBytes, "jpg", TipoUploadS3.PEDIDO);
+    }
 
-  private String buildImageUrl(String key) {
-    return baseUrl + key;
-  }
+    public String uploadFile(byte[] bytes, String extension, TipoUploadS3 tipoUpload) {
+        try {
+            String key = construirChaveS3(extension, tipoUpload);
+            logger.info("Iniciando upload para S3 com chave: {}", key);
+            s3Template.upload(bucketName, key, new ByteArrayInputStream(bytes));
+            String url = buildImageUrl(key);
+            logger.info("Arquivo enviado para S3. URL: {}", url);
+            return url;
+        } catch (Exception e) {
+            logger.error("Erro ao fazer upload do arquivo para S3", e);
+            throw new S3UploadException("Falha ao salvar arquivo no S3: " + e.getMessage(), e);
+        }
+    }
+
+    private String construirChaveS3(String extension, TipoUploadS3 tipoUpload) {
+        String today = LocalDate.now().format(DATE_FORMATTER);
+        return String.format("%s/%s/%s.%s", tipoUpload.getFolder(), today, UUID.randomUUID(), extension);
+    }
+
+    private String buildImageUrl(String key) {
+        return baseUrl + key;
+    }
 }
-

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/dto/ResumoMesDTO.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/dto/ResumoMesDTO.java
@@ -2,9 +2,10 @@ package br.com.satyan.stering.saita.financasbottelegram.application.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "Resumo do mês atual: contagem e total de pendentes e pagos")
+@Schema(description = "Resumo de um mês: contagem e total por status (todos, pendentes, pagos)")
 public record ResumoMesDTO(
-        @Schema(description = "Mês de referência no formato YYYY-MM", example = "2026-05") String mesAtual,
+        @Schema(description = "Mês de referência no formato YYYY-MM", example = "2026-05") String mes,
+        ResumoStatusDTO todos,
         ResumoStatusDTO pendentes,
         ResumoStatusDTO pagos
 ) {}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/services/ResumoMesServiceImpl.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/services/ResumoMesServiceImpl.java
@@ -9,6 +9,8 @@ import br.com.satyan.stering.saita.financasbottelegram.domain.enums.StatusPedido
 import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -26,20 +28,30 @@ public class ResumoMesServiceImpl implements ResumoMesUseCase {
     }
 
     @Override
-    public ResumoMesDTO obter(Long requisitanteId) {
-        LocalDate hoje = LocalDate.now(clock);
-        LocalDate inicio = hoje.withDayOfMonth(1);
-        LocalDate fim = hoje.withDayOfMonth(hoje.lengthOfMonth());
+    public ResumoMesDTO obter(Long requisitanteId, YearMonth ym, String busca) {
+        YearMonth mes = ym != null ? ym : YearMonth.now(clock);
+        LocalDate inicio = mes.atDay(1);
+        LocalDate fim = mes.atEndOfMonth();
 
-        Map<StatusPedido, AgregadoStatus> porStatus = repo
-                .agregarPorStatusNoIntervalo(requisitanteId, inicio, fim).stream()
+        List<AgregadoStatus> agregados;
+        if (busca != null && !busca.isBlank()) {
+            String pattern = "%" + busca.toLowerCase() + "%";
+            agregados = repo.agregarPorStatusNoIntervaloComBusca(requisitanteId, inicio, fim, pattern);
+        } else {
+            agregados = repo.agregarPorStatusNoIntervalo(requisitanteId, inicio, fim);
+        }
+
+        Map<StatusPedido, AgregadoStatus> porStatus = agregados.stream()
                 .collect(Collectors.toMap(AgregadoStatus::status, Function.identity()));
 
         ResumoStatusDTO pendentes = toDTO(porStatus.get(StatusPedido.PENDENTE));
         ResumoStatusDTO pagos = toDTO(porStatus.get(StatusPedido.PAGO));
+        ResumoStatusDTO todos = new ResumoStatusDTO(
+                pendentes.quantidade() + pagos.quantidade(),
+                pendentes.total().add(pagos.total()));
 
-        String mesAtual = String.format("%04d-%02d", hoje.getYear(), hoje.getMonthValue());
-        return new ResumoMesDTO(mesAtual, pendentes, pagos);
+        String mesStr = String.format("%04d-%02d", mes.getYear(), mes.getMonthValue());
+        return new ResumoMesDTO(mesStr, todos, pendentes, pagos);
     }
 
     private ResumoStatusDTO toDTO(AgregadoStatus a) {

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/usecases/ResumoMesUseCase.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/usecases/ResumoMesUseCase.java
@@ -1,8 +1,9 @@
 package br.com.satyan.stering.saita.financasbottelegram.application.usecases;
 
 import br.com.satyan.stering.saita.financasbottelegram.application.dto.ResumoMesDTO;
+import java.time.YearMonth;
 
 public interface ResumoMesUseCase {
 
-    ResumoMesDTO obter(Long requisitanteId);
+    ResumoMesDTO obter(Long requisitanteId, YearMonth mes, String busca);
 }

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/domain/enums/TipoUploadS3.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/domain/enums/TipoUploadS3.java
@@ -1,0 +1,16 @@
+package br.com.satyan.stering.saita.financasbottelegram.domain.enums;
+
+public enum TipoUploadS3 {
+    PEDIDO("pedidos"),
+    COMPROVANTE("comprovantes");
+
+    private final String folder;
+
+    TipoUploadS3(String folder) {
+        this.folder = folder;
+    }
+
+    public String getFolder() {
+        return folder;
+    }
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/domain/exceptions/MesFormatoInvalidoException.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/domain/exceptions/MesFormatoInvalidoException.java
@@ -1,0 +1,8 @@
+package br.com.satyan.stering.saita.financasbottelegram.domain.exceptions;
+
+public class MesFormatoInvalidoException extends RuntimeException {
+
+    public MesFormatoInvalidoException(String mes) {
+        super("Formato de mês inválido: '" + mes + "'. Use YYYY-MM (ex: 2026-05).");
+    }
+}

--- a/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/rest/resumo/ResumoControllerTest.java
+++ b/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/rest/resumo/ResumoControllerTest.java
@@ -1,17 +1,22 @@
 package br.com.satyan.stering.saita.financasbottelegram.adapters.in.rest.resumo;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import br.com.satyan.stering.saita.financasbottelegram.application.dto.ResumoMesDTO;
 import br.com.satyan.stering.saita.financasbottelegram.application.dto.ResumoStatusDTO;
 import br.com.satyan.stering.saita.financasbottelegram.application.usecases.ResumoMesUseCase;
+import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.MesFormatoInvalidoException;
 import java.math.BigDecimal;
+import java.time.YearMonth;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -22,6 +27,8 @@ class ResumoControllerTest {
 
     private ResumoController controller;
 
+    private static final ResumoStatusDTO ZEROS = new ResumoStatusDTO(0, BigDecimal.ZERO);
+
     @BeforeEach
     void setUp() {
         controller = new ResumoController(useCase);
@@ -29,26 +36,54 @@ class ResumoControllerTest {
 
     @Test
     void deveRetornarDTODoUseCase() {
-        ResumoMesDTO esperado = new ResumoMesDTO("2026-05",
-                new ResumoStatusDTO(3, new BigDecimal("900.00")),
-                new ResumoStatusDTO(2, new BigDecimal("500.00")));
-        when(useCase.obter(42L)).thenReturn(esperado);
+        ResumoMesDTO esperado = new ResumoMesDTO("2026-05", ZEROS, ZEROS, ZEROS);
+        when(useCase.obter(eq(42L), isNull(), isNull())).thenReturn(esperado);
 
-        ResumoMesDTO resultado = controller.obter(42L);
+        ResumoMesDTO resultado = controller.obter(42L, null, null);
 
         assertThat(resultado).isEqualTo(esperado);
     }
 
     @Test
-    void devePassarRequisitanteIdCorretamente() {
-        when(useCase.obter(7L)).thenReturn(new ResumoMesDTO("2026-05",
-                new ResumoStatusDTO(0, BigDecimal.ZERO),
-                new ResumoStatusDTO(0, BigDecimal.ZERO)));
+    void devePassarYearMonthParsadoCorretamente() {
+        when(useCase.obter(eq(1L), eq(YearMonth.of(2026, 3)), isNull()))
+                .thenReturn(new ResumoMesDTO("2026-03", ZEROS, ZEROS, ZEROS));
 
-        controller.obter(7L);
+        controller.obter(1L, "2026-03", null);
 
-        ArgumentCaptor<Long> captor = ArgumentCaptor.forClass(Long.class);
-        verify(useCase).obter(captor.capture());
-        assertThat(captor.getValue()).isEqualTo(7L);
+        verify(useCase).obter(eq(1L), eq(YearMonth.of(2026, 3)), isNull());
+    }
+
+    @Test
+    void devePassarBuscaCorretamente() {
+        when(useCase.obter(eq(1L), isNull(), eq("pix"))).thenReturn(new ResumoMesDTO("2026-05", ZEROS, ZEROS, ZEROS));
+
+        controller.obter(1L, null, "pix");
+
+        verify(useCase).obter(eq(1L), isNull(), eq("pix"));
+    }
+
+    @Test
+    void deveLancarMesFormatoInvalidoExceptionParaMesInvalido() {
+        assertThatThrownBy(() -> controller.obter(1L, "2026-13", null))
+                .isInstanceOf(MesFormatoInvalidoException.class)
+                .hasMessageContaining("2026-13");
+    }
+
+    @Test
+    void deveLancarMesFormatoInvalidoExceptionParaFormatoErrado() {
+        assertThatThrownBy(() -> controller.obter(1L, "05-2026", null))
+                .isInstanceOf(MesFormatoInvalidoException.class);
+    }
+
+    @Test
+    void devePassarMesNuloQuandoMesParametroNuloOuBranco() {
+        when(useCase.obter(eq(7L), isNull(), isNull())).thenReturn(new ResumoMesDTO("2026-05", ZEROS, ZEROS, ZEROS));
+
+        controller.obter(7L, null, null);
+        controller.obter(7L, "", null);
+        controller.obter(7L, "   ", null);
+
+        verify(useCase, org.mockito.Mockito.times(3)).obter(eq(7L), isNull(), isNull());
     }
 }

--- a/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/telegram/strategy/PaymentProofStrategyTest.java
+++ b/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/telegram/strategy/PaymentProofStrategyTest.java
@@ -15,6 +15,7 @@ import br.com.satyan.stering.saita.financasbottelegram.adapters.out.telegram.ser
 import br.com.satyan.stering.saita.financasbottelegram.adapters.out.telegram.service.TelegramMessageSenderService;
 import br.com.satyan.stering.saita.financasbottelegram.application.usecases.RegistrarComprovanteUsecase;
 import br.com.satyan.stering.saita.financasbottelegram.domain.enums.TipoArquivo;
+import br.com.satyan.stering.saita.financasbottelegram.domain.enums.TipoUploadS3;
 import br.com.satyan.stering.saita.financasbottelegram.domain.model.Comprovante;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -66,7 +67,7 @@ class PaymentProofStrategyTest {
     void deveProcessarComprovanteComSucesso() {
         Update update = updateComFoto("#123 PIX", 12345L, "file_xyz");
         when(telegramFileDownloaderService.downloadImageByFileId("file_xyz")).thenReturn(new byte[]{1, 2, 3});
-        when(s3ImageUploadService.uploadFile(any(), any())).thenReturn("https://s3.example.com/comprovante.jpg");
+        when(s3ImageUploadService.uploadFile(any(), any(), any())).thenReturn("https://s3.example.com/comprovante.jpg");
         Comprovante salvo = Comprovante.builder().id(1L).pedidoId(123L).tipoPagamento("PIX").build();
         when(registrarComprovanteUsecase.execute(eq(123L), eq("PIX"), eq("file_xyz"), any(), eq(TipoArquivo.IMAGEM), eq(12345L))).thenReturn(salvo);
 
@@ -88,7 +89,7 @@ class PaymentProofStrategyTest {
     void deveConverterTipoPagamentoParaMaiusculo() {
         Update update = updateComFoto("#10 ted", 12345L, "file_abc");
         when(telegramFileDownloaderService.downloadImageByFileId(any())).thenReturn(new byte[]{});
-        when(s3ImageUploadService.uploadFile(any(), any())).thenReturn("https://s3.example.com/img.jpg");
+        when(s3ImageUploadService.uploadFile(any(), any(), any())).thenReturn("https://s3.example.com/img.jpg");
         Comprovante salvo = Comprovante.builder().id(2L).pedidoId(10L).tipoPagamento("TED").build();
         when(registrarComprovanteUsecase.execute(eq(10L), eq("TED"), any(), any(), eq(TipoArquivo.IMAGEM), eq(12345L))).thenReturn(salvo);
 
@@ -103,7 +104,7 @@ class PaymentProofStrategyTest {
     void deveAceitarDocumentComMimeTypeImageJpeg() {
         Update update = updateComDocument("#50 pix", 12345L, "doc_jpg", "image/jpeg");
         when(telegramFileDownloaderService.downloadImageByFileId("doc_jpg")).thenReturn(new byte[]{});
-        when(s3ImageUploadService.uploadFile(any(), eq("jpg"))).thenReturn("https://s3.example.com/file.jpg");
+        when(s3ImageUploadService.uploadFile(any(), eq("jpg"), any())).thenReturn("https://s3.example.com/file.jpg");
         Comprovante salvo = Comprovante.builder().id(3L).pedidoId(50L).tipoPagamento("PIX").build();
         when(registrarComprovanteUsecase.execute(eq(50L), eq("PIX"), eq("doc_jpg"), any(), eq(TipoArquivo.IMAGEM), eq(12345L))).thenReturn(salvo);
 
@@ -116,7 +117,7 @@ class PaymentProofStrategyTest {
     void deveAceitarDocumentComMimeTypePdf() {
         Update update = updateComDocument("#99 boleto", 12345L, "doc_pdf", "application/pdf");
         when(telegramFileDownloaderService.downloadImageByFileId("doc_pdf")).thenReturn(new byte[]{});
-        when(s3ImageUploadService.uploadFile(any(), eq("pdf"))).thenReturn("https://s3.example.com/file.pdf");
+        when(s3ImageUploadService.uploadFile(any(), eq("pdf"), any())).thenReturn("https://s3.example.com/file.pdf");
         Comprovante salvo = Comprovante.builder().id(4L).pedidoId(99L).tipoPagamento("BOLETO").build();
         when(registrarComprovanteUsecase.execute(eq(99L), eq("BOLETO"), eq("doc_pdf"), any(), eq(TipoArquivo.PDF), eq(12345L))).thenReturn(salvo);
 
@@ -129,13 +130,26 @@ class PaymentProofStrategyTest {
     void deveAceitarDocumentOctetStreamComoImagem() {
         Update update = updateComDocument("#77 ted", 12345L, "doc_ws", "application/octet-stream");
         when(telegramFileDownloaderService.downloadImageByFileId("doc_ws")).thenReturn(new byte[]{});
-        when(s3ImageUploadService.uploadFile(any(), eq("jpg"))).thenReturn("https://s3.example.com/file.jpg");
+        when(s3ImageUploadService.uploadFile(any(), eq("jpg"), any())).thenReturn("https://s3.example.com/file.jpg");
         Comprovante salvo = Comprovante.builder().id(5L).pedidoId(77L).tipoPagamento("TED").build();
         when(registrarComprovanteUsecase.execute(eq(77L), eq("TED"), eq("doc_ws"), any(), eq(TipoArquivo.IMAGEM), eq(12345L))).thenReturn(salvo);
 
         strategy.process(update);
 
         verify(registrarComprovanteUsecase).execute(eq(77L), eq("TED"), eq("doc_ws"), any(), eq(TipoArquivo.IMAGEM), eq(12345L));
+    }
+
+    @Test
+    void deveUsarTipoUploadComprovanteNoS3() {
+        Update update = updateComFoto("#20 pix", 12345L, "file_chk");
+        when(telegramFileDownloaderService.downloadImageByFileId(any())).thenReturn(new byte[]{});
+        when(s3ImageUploadService.uploadFile(any(), any(), any())).thenReturn("https://s3.example.com/comprovantes/abc.jpg");
+        Comprovante salvo = Comprovante.builder().id(9L).pedidoId(20L).tipoPagamento("PIX").build();
+        when(registrarComprovanteUsecase.execute(any(), any(), any(), any(), any(), any())).thenReturn(salvo);
+
+        strategy.process(update);
+
+        verify(s3ImageUploadService).uploadFile(any(), any(), eq(TipoUploadS3.COMPROVANTE));
     }
 
     @Test

--- a/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/telegram/strategy/PaymentRequestStrategyTest.java
+++ b/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/telegram/strategy/PaymentRequestStrategyTest.java
@@ -16,6 +16,7 @@ import br.com.satyan.stering.saita.financasbottelegram.adapters.out.telegram.ser
 import br.com.satyan.stering.saita.financasbottelegram.application.usecases.SalvarPedidoPagamentoUsecase;
 import br.com.satyan.stering.saita.financasbottelegram.domain.enums.StatusPedido;
 import br.com.satyan.stering.saita.financasbottelegram.domain.enums.TipoPagamento;
+import br.com.satyan.stering.saita.financasbottelegram.domain.enums.TipoUploadS3;
 import br.com.satyan.stering.saita.financasbottelegram.domain.model.PedidoPagamento;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -71,7 +72,7 @@ class PaymentRequestStrategyTest {
     void deveProcessarPedidoComTodosOsDados() {
         Update update = updateCompleto("150.50 Almoço com cliente", 12345L, 99L, 10, "file_abc");
         when(telegramFileDownloaderService.downloadImageByFileId("file_abc")).thenReturn(new byte[]{1, 2, 3});
-        when(s3ImageUploadService.uploadFile(any(), any())).thenReturn("https://s3.example.com/foto.jpg");
+        when(s3ImageUploadService.uploadFile(any(), any(), any())).thenReturn("https://s3.example.com/foto.jpg");
         PedidoPagamento salvo = PedidoPagamento.builder().id(1L).valor(new BigDecimal("150.50")).descricao("Almoço com cliente").tipo(TipoPagamento.OUTRO).build();
         when(salvarPedidoPagamentoUsecase.execute(any(), eq(12345L))).thenReturn(salvo);
 
@@ -94,7 +95,7 @@ class PaymentRequestStrategyTest {
     void deveConverterValorComVirgulaParaBigDecimal() {
         Update update = updateCompleto("99,90 Café", 12345L, 99L, 10, "file_001");
         when(telegramFileDownloaderService.downloadImageByFileId(any())).thenReturn(new byte[]{});
-        when(s3ImageUploadService.uploadFile(any(), any())).thenReturn("https://s3.example.com/foto.jpg");
+        when(s3ImageUploadService.uploadFile(any(), any(), any())).thenReturn("https://s3.example.com/foto.jpg");
         PedidoPagamento salvo = PedidoPagamento.builder().id(2L).valor(new BigDecimal("99.90")).descricao("Café").tipo(TipoPagamento.OUTRO).build();
         when(salvarPedidoPagamentoUsecase.execute(any(), any())).thenReturn(salvo);
 
@@ -109,7 +110,7 @@ class PaymentRequestStrategyTest {
     void deveMostrarTipoNaMensagemDeSucesso() {
         Update update = updateCompleto("200 pix Maria", 12345L, 99L, 10, "file_pix");
         when(telegramFileDownloaderService.downloadImageByFileId(any())).thenReturn(new byte[]{});
-        when(s3ImageUploadService.uploadFile(any(), any())).thenReturn("https://s3.example.com/foto.jpg");
+        when(s3ImageUploadService.uploadFile(any(), any(), any())).thenReturn("https://s3.example.com/foto.jpg");
         PedidoPagamento salvo = PedidoPagamento.builder().id(3L).valor(new BigDecimal("200")).descricao("pix Maria").tipo(TipoPagamento.PIX).build();
         when(salvarPedidoPagamentoUsecase.execute(any(), any())).thenReturn(salvo);
 
@@ -122,7 +123,7 @@ class PaymentRequestStrategyTest {
     void deveMostrarDicaQuandoTipoForOUTRO() {
         Update update = updateCompleto("50 Almoço", 12345L, 99L, 10, "file_outro");
         when(telegramFileDownloaderService.downloadImageByFileId(any())).thenReturn(new byte[]{});
-        when(s3ImageUploadService.uploadFile(any(), any())).thenReturn("https://s3.example.com/foto.jpg");
+        when(s3ImageUploadService.uploadFile(any(), any(), any())).thenReturn("https://s3.example.com/foto.jpg");
         PedidoPagamento salvo = PedidoPagamento.builder().id(4L).valor(new BigDecimal("50")).descricao("Almoço").tipo(TipoPagamento.OUTRO).build();
         when(salvarPedidoPagamentoUsecase.execute(any(), any())).thenReturn(salvo);
 
@@ -135,13 +136,26 @@ class PaymentRequestStrategyTest {
     void deveAceitarDocumentPdfComoPedido() {
         Update update = updateComDocument("500 boleto Energia", 12345L, 99L, 10, "doc_pdf", "application/pdf");
         when(telegramFileDownloaderService.downloadImageByFileId("doc_pdf")).thenReturn(new byte[]{});
-        when(s3ImageUploadService.uploadFile(any(), eq("pdf"))).thenReturn("https://s3.example.com/file.pdf");
+        when(s3ImageUploadService.uploadFile(any(), eq("pdf"), any())).thenReturn("https://s3.example.com/file.pdf");
         PedidoPagamento salvo = PedidoPagamento.builder().id(5L).valor(new BigDecimal("500")).descricao("boleto Energia").tipo(TipoPagamento.BOLETO).build();
         when(salvarPedidoPagamentoUsecase.execute(any(), any())).thenReturn(salvo);
 
         strategy.process(update);
 
-        verify(s3ImageUploadService).uploadFile(any(), eq("pdf"));
+        verify(s3ImageUploadService).uploadFile(any(), eq("pdf"), eq(TipoUploadS3.PEDIDO));
+    }
+
+    @Test
+    void deveUsarTipoUploadPedidoNoS3() {
+        Update update = updateCompleto("100 pix Teste", 12345L, 99L, 10, "file_chk");
+        when(telegramFileDownloaderService.downloadImageByFileId(any())).thenReturn(new byte[]{});
+        when(s3ImageUploadService.uploadFile(any(), any(), any())).thenReturn("https://s3.example.com/pedidos/abc.jpg");
+        PedidoPagamento salvo = PedidoPagamento.builder().id(9L).valor(new BigDecimal("100")).descricao("pix Teste").tipo(TipoPagamento.PIX).build();
+        when(salvarPedidoPagamentoUsecase.execute(any(), any())).thenReturn(salvo);
+
+        strategy.process(update);
+
+        verify(s3ImageUploadService).uploadFile(any(), any(), eq(TipoUploadS3.PEDIDO));
     }
 
     @Test

--- a/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/s3/service/S3ImageUploadServiceTest.java
+++ b/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/s3/service/S3ImageUploadServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
+import br.com.satyan.stering.saita.financasbottelegram.domain.enums.TipoUploadS3;
 import io.awspring.cloud.s3.S3Template;
 import java.io.InputStream;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,32 +32,42 @@ class S3ImageUploadServiceTest {
     }
 
     @Test
-    void uploadFile_deveRetornarUrlComExtensaoJpg() {
-        String url = service.uploadFile(new byte[]{1, 2, 3}, "jpg");
+    void uploadFile_pedido_deveGerarChaveComPrefixoPedidos() {
+        String url = service.uploadFile(new byte[]{1, 2, 3}, "jpg", TipoUploadS3.PEDIDO);
 
         assertThat(url).startsWith(BASE_URL + "pedidos/");
         assertThat(url).endsWith(".jpg");
     }
 
     @Test
-    void uploadFile_deveRetornarUrlComExtensaoPdf() {
-        String url = service.uploadFile(new byte[]{1, 2, 3}, "pdf");
+    void uploadFile_comprovante_deveGerarChaveComPrefixoComprovantes() {
+        String url = service.uploadFile(new byte[]{1, 2, 3}, "pdf", TipoUploadS3.COMPROVANTE);
 
-        assertThat(url).startsWith(BASE_URL + "pedidos/");
+        assertThat(url).startsWith(BASE_URL + "comprovantes/");
         assertThat(url).endsWith(".pdf");
     }
 
     @Test
+    void uploadFile_deveConterDataNoFormato_YYYYMMDD() {
+        String url = service.uploadFile(new byte[]{}, "jpg", TipoUploadS3.PEDIDO);
+
+        String chave = url.replace(BASE_URL, "");
+        String[] partes = chave.split("/");
+        assertThat(partes[1]).matches("\\d{8}");
+    }
+
+    @Test
     void uploadFile_deveChamarS3TemplateComBucketCorreto() {
-        service.uploadFile(new byte[]{}, "jpg");
+        service.uploadFile(new byte[]{}, "jpg", TipoUploadS3.PEDIDO);
 
         verify(s3Template).upload(eq(BUCKET), any(), any(InputStream.class));
     }
 
     @Test
-    void uploadImage_deveDelegarParaUploadFileComExtensaoJpg() {
+    void uploadImage_deveDelegarParaPedidoComExtensaoJpg() {
         String url = service.uploadImage(new byte[]{1});
 
+        assertThat(url).startsWith(BASE_URL + "pedidos/");
         assertThat(url).endsWith(".jpg");
         verify(s3Template).upload(eq(BUCKET), any(), any(InputStream.class));
     }
@@ -65,15 +76,15 @@ class S3ImageUploadServiceTest {
     void uploadFile_deveLancarS3UploadExceptionQuandoS3Falha() {
         doThrow(new RuntimeException("S3 indisponível")).when(s3Template).upload(any(), any(), any());
 
-        assertThatThrownBy(() -> service.uploadFile(new byte[]{}, "jpg"))
+        assertThatThrownBy(() -> service.uploadFile(new byte[]{}, "jpg", TipoUploadS3.PEDIDO))
                 .isInstanceOf(S3UploadException.class)
                 .hasMessageContaining("Falha ao salvar arquivo no S3");
     }
 
     @Test
     void uploadFile_deveGerarChavesUnicasParaUploadsDistintos() {
-        String url1 = service.uploadFile(new byte[]{}, "png");
-        String url2 = service.uploadFile(new byte[]{}, "png");
+        String url1 = service.uploadFile(new byte[]{}, "png", TipoUploadS3.PEDIDO);
+        String url2 = service.uploadFile(new byte[]{}, "png", TipoUploadS3.PEDIDO);
 
         assertThat(url1).isNotEqualTo(url2);
     }

--- a/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/application/dto/ResumoMesDTOTest.java
+++ b/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/application/dto/ResumoMesDTOTest.java
@@ -12,19 +12,32 @@ class ResumoMesDTOTest {
 
     @Test
     void deveSerializarResumoComNested() throws Exception {
-        ResumoMesDTO dto = new ResumoMesDTO(
-                "2026-05",
-                new ResumoStatusDTO(3, new BigDecimal("450.00")),
-                new ResumoStatusDTO(7, new BigDecimal("1230.50"))
-        );
+        ResumoStatusDTO todos = new ResumoStatusDTO(10, new BigDecimal("1680.50"));
+        ResumoStatusDTO pendentes = new ResumoStatusDTO(3, new BigDecimal("450.00"));
+        ResumoStatusDTO pagos = new ResumoStatusDTO(7, new BigDecimal("1230.50"));
+        ResumoMesDTO dto = new ResumoMesDTO("2026-05", todos, pendentes, pagos);
 
         String json = mapper.writeValueAsString(dto);
 
-        assertThat(json).contains("\"mesAtual\":\"2026-05\"");
+        assertThat(json).contains("\"mes\":\"2026-05\"");
+        assertThat(json).contains("\"todos\"");
         assertThat(json).contains("\"pendentes\"");
+        assertThat(json).contains("\"pagos\"");
+        assertThat(json).contains("\"quantidade\":10");
         assertThat(json).contains("\"quantidade\":3");
         assertThat(json).contains("\"quantidade\":7");
-        assertThat(json).contains("\"total\":450.00");
-        assertThat(json).contains("\"total\":1230.50");
+        assertThat(json).contains("\"total\":1680.50");
+    }
+
+    @Test
+    void naoDeveConterCampoMesAtual() throws Exception {
+        ResumoMesDTO dto = new ResumoMesDTO("2026-05",
+                new ResumoStatusDTO(0, BigDecimal.ZERO),
+                new ResumoStatusDTO(0, BigDecimal.ZERO),
+                new ResumoStatusDTO(0, BigDecimal.ZERO));
+
+        String json = mapper.writeValueAsString(dto);
+
+        assertThat(json).doesNotContain("mesAtual");
     }
 }

--- a/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/application/services/ResumoMesServiceImplTest.java
+++ b/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/application/services/ResumoMesServiceImplTest.java
@@ -3,6 +3,7 @@ package br.com.satyan.stering.saita.financasbottelegram.application.services;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import br.com.satyan.stering.saita.financasbottelegram.adapters.out.persistence.AgregadoStatus;
@@ -13,6 +14,7 @@ import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.time.ZoneId;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,12 +38,26 @@ class ResumoMesServiceImplTest {
     }
 
     @Test
-    void deveRetornarMesAtualNoFormatoCorreto() {
+    void deveUsarMesCorrenteQuandoMesNulo() {
         when(repo.agregarPorStatusNoIntervalo(eq(1L), any(), any())).thenReturn(List.of());
 
-        ResumoMesDTO dto = service.obter(1L);
+        ResumoMesDTO dto = service.obter(1L, null, null);
 
-        assertThat(dto.mesAtual()).isEqualTo("2026-05");
+        assertThat(dto.mes()).isEqualTo("2026-05");
+    }
+
+    @Test
+    void deveUsarMesEspecificoQuandoInformado() {
+        when(repo.agregarPorStatusNoIntervalo(eq(1L),
+                eq(LocalDate.of(2026, 4, 1)),
+                eq(LocalDate.of(2026, 4, 30)))).thenReturn(List.of());
+
+        ResumoMesDTO dto = service.obter(1L, YearMonth.of(2026, 4), null);
+
+        assertThat(dto.mes()).isEqualTo("2026-04");
+        verify(repo).agregarPorStatusNoIntervalo(eq(1L),
+                eq(LocalDate.of(2026, 4, 1)),
+                eq(LocalDate.of(2026, 4, 30)));
     }
 
     @Test
@@ -50,7 +66,7 @@ class ResumoMesServiceImplTest {
         AgregadoStatus pagos = new AgregadoStatus(StatusPedido.PAGO, 2, new BigDecimal("500.00"));
         when(repo.agregarPorStatusNoIntervalo(eq(1L), any(), any())).thenReturn(List.of(pendentes, pagos));
 
-        ResumoMesDTO dto = service.obter(1L);
+        ResumoMesDTO dto = service.obter(1L, null, null);
 
         assertThat(dto.pendentes().quantidade()).isEqualTo(3);
         assertThat(dto.pendentes().total()).isEqualByComparingTo("900.00");
@@ -59,15 +75,59 @@ class ResumoMesServiceImplTest {
     }
 
     @Test
+    void deveCalcularTodosComSomaDePendentesEPagos() {
+        AgregadoStatus pendentes = new AgregadoStatus(StatusPedido.PENDENTE, 3, new BigDecimal("900.00"));
+        AgregadoStatus pagos = new AgregadoStatus(StatusPedido.PAGO, 2, new BigDecimal("500.00"));
+        when(repo.agregarPorStatusNoIntervalo(eq(1L), any(), any())).thenReturn(List.of(pendentes, pagos));
+
+        ResumoMesDTO dto = service.obter(1L, null, null);
+
+        assertThat(dto.todos().quantidade()).isEqualTo(5);
+        assertThat(dto.todos().total()).isEqualByComparingTo("1400.00");
+    }
+
+    @Test
     void deveRetornarZerosQuandoSemPedidosNoMes() {
         when(repo.agregarPorStatusNoIntervalo(eq(1L), any(), any())).thenReturn(List.of());
 
-        ResumoMesDTO dto = service.obter(1L);
+        ResumoMesDTO dto = service.obter(1L, null, null);
+
+        assertThat(dto.todos().quantidade()).isZero();
+        assertThat(dto.todos().total()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(dto.pendentes().quantidade()).isZero();
+        assertThat(dto.pagos().quantidade()).isZero();
+    }
+
+    @Test
+    void deveUsarQueryComBuscaQuandoBuscaNaoNula() {
+        when(repo.agregarPorStatusNoIntervaloComBusca(eq(1L), any(), any(), eq("%pix%")))
+                .thenReturn(List.of());
+
+        service.obter(1L, null, "PIX");
+
+        verify(repo).agregarPorStatusNoIntervaloComBusca(eq(1L), any(), any(), eq("%pix%"));
+    }
+
+    @Test
+    void deveUsarQuerySemBuscaQuandoBuscaNulaOuBranca() {
+        when(repo.agregarPorStatusNoIntervalo(eq(1L), any(), any())).thenReturn(List.of());
+
+        service.obter(1L, null, null);
+        service.obter(1L, null, "   ");
+
+        verify(repo, org.mockito.Mockito.times(2)).agregarPorStatusNoIntervalo(eq(1L), any(), any());
+    }
+
+    @Test
+    void deveIgnorarStatusCancelado() {
+        AgregadoStatus cancelados = new AgregadoStatus(StatusPedido.CANCELADO, 5, new BigDecimal("1000.00"));
+        when(repo.agregarPorStatusNoIntervalo(eq(1L), any(), any())).thenReturn(List.of(cancelados));
+
+        ResumoMesDTO dto = service.obter(1L, null, null);
 
         assertThat(dto.pendentes().quantidade()).isZero();
-        assertThat(dto.pendentes().total()).isEqualByComparingTo(BigDecimal.ZERO);
         assertThat(dto.pagos().quantidade()).isZero();
-        assertThat(dto.pagos().total()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(dto.todos().quantidade()).isZero();
     }
 
     @Test
@@ -77,17 +137,10 @@ class ResumoMesServiceImplTest {
                 eq(LocalDate.of(2026, 5, 31))))
                 .thenReturn(List.of());
 
-        service.obter(1L);
-    }
+        service.obter(1L, null, null);
 
-    @Test
-    void deveIgnorarStatusCancelado() {
-        AgregadoStatus cancelados = new AgregadoStatus(StatusPedido.CANCELADO, 5, new BigDecimal("1000.00"));
-        when(repo.agregarPorStatusNoIntervalo(eq(1L), any(), any())).thenReturn(List.of(cancelados));
-
-        ResumoMesDTO dto = service.obter(1L);
-
-        assertThat(dto.pendentes().quantidade()).isZero();
-        assertThat(dto.pagos().quantidade()).isZero();
+        verify(repo).agregarPorStatusNoIntervalo(eq(1L),
+                eq(LocalDate.of(2026, 5, 1)),
+                eq(LocalDate.of(2026, 5, 31)));
     }
 }

--- a/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/integration/ResumoIntegrationTest.java
+++ b/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/integration/ResumoIntegrationTest.java
@@ -3,8 +3,6 @@ package br.com.satyan.stering.saita.financasbottelegram.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import br.com.satyan.stering.saita.financasbottelegram.application.dto.ResumoMesDTO;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -19,45 +17,64 @@ class ResumoIntegrationTest extends AbstractIntegrationTest {
         jdbcTemplate.update("DELETE FROM comprovantes WHERE pedido_id IN (SELECT id FROM pedidos_pagamento WHERE requisitante_id = 1)");
         jdbcTemplate.update("DELETE FROM pedidos_pagamento WHERE requisitante_id = 1");
 
+        // 2 pendentes maio, 1 pago maio, 1 pago abril, 1 cancelado maio
         jdbcTemplate.update("""
                 INSERT INTO pedidos_pagamento (requisitante_id, valor, descricao, status, tipo, data_pedido, data_criacao)
-                VALUES (1, 100.00, 'P1', 'PENDENTE', 'PIX', CURDATE(), NOW()),
-                       (1, 200.00, 'P2', 'PENDENTE', 'BOLETO', CURDATE(), NOW()),
-                       (1, 500.00, 'P3', 'PAGO', 'TED', CURDATE(), NOW()),
-                       (1, 999.00, 'P4', 'CANCELADO', 'OUTRO', CURDATE(), NOW())
+                VALUES (1, 100.00, 'boleto Energia',  'PENDENTE',  'BOLETO', '2026-05-10', NOW()),
+                       (1, 200.00, 'pix Maria',       'PENDENTE',  'PIX',    '2026-05-15', NOW()),
+                       (1, 500.00, 'ted Construtora', 'PAGO',      'TED',    '2026-05-20', NOW()),
+                       (1, 999.00, 'boleto Agua',     'PAGO',      'BOLETO', '2026-04-05', NOW()),
+                       (1, 150.00, 'cancelado',       'CANCELADO', 'OUTRO',  '2026-05-01', NOW())
                 """);
 
         cookie = autenticarComo(1L);
     }
 
     @Test
-    void resumo_retorna200ComAgregadoCorreto() {
-        ResponseEntity<ResumoMesDTO> resp = getAutenticado("/api/v1/resumo", cookie, ResumoMesDTO.class);
+    void resumo_comMesEspecifico_retornaAgregadoCorreto() {
+        ResponseEntity<ResumoMesDTO> resp = getAutenticado("/api/v1/resumo?mes=2026-05", cookie, ResumoMesDTO.class);
 
         assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
         ResumoMesDTO body = resp.getBody();
         assertThat(body).isNotNull();
-
-        String mesEsperado = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM"));
-        assertThat(body.mesAtual()).isEqualTo(mesEsperado);
-
+        assertThat(body.mes()).isEqualTo("2026-05");
         assertThat(body.pendentes().quantidade()).isEqualTo(2);
         assertThat(body.pendentes().total().doubleValue()).isEqualTo(300.00);
         assertThat(body.pagos().quantidade()).isEqualTo(1);
         assertThat(body.pagos().total().doubleValue()).isEqualTo(500.00);
+        assertThat(body.todos().quantidade()).isEqualTo(3);
+        assertThat(body.todos().total().doubleValue()).isEqualTo(800.00);
+    }
+
+    @Test
+    void resumo_comBusca_filtraPorDescricao() {
+        ResponseEntity<ResumoMesDTO> resp = getAutenticado("/api/v1/resumo?mes=2026-05&busca=boleto", cookie, ResumoMesDTO.class);
+
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+        ResumoMesDTO body = resp.getBody();
+        assertThat(body.pendentes().quantidade()).isEqualTo(1);
+        assertThat(body.pendentes().total().doubleValue()).isEqualTo(100.00);
+        assertThat(body.pagos().quantidade()).isZero();
+        assertThat(body.todos().quantidade()).isEqualTo(1);
     }
 
     @Test
     void resumo_semPedidosNoMes_retornaZeros() {
-        jdbcTemplate.update("DELETE FROM comprovantes WHERE pedido_id IN (SELECT id FROM pedidos_pagamento WHERE requisitante_id = 1)");
-        jdbcTemplate.update("DELETE FROM pedidos_pagamento WHERE requisitante_id = 1");
-
-        ResponseEntity<ResumoMesDTO> resp = getAutenticado("/api/v1/resumo", cookie, ResumoMesDTO.class);
+        ResponseEntity<ResumoMesDTO> resp = getAutenticado("/api/v1/resumo?mes=2020-01", cookie, ResumoMesDTO.class);
 
         assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
         ResumoMesDTO body = resp.getBody();
         assertThat(body.pendentes().quantidade()).isZero();
         assertThat(body.pagos().quantidade()).isZero();
+        assertThat(body.todos().quantidade()).isZero();
+    }
+
+    @Test
+    void resumo_mesInvalido_retorna400() {
+        ResponseEntity<String> resp = getAutenticado("/api/v1/resumo?mes=2026-13", cookie, String.class);
+
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(resp.getBody()).contains("MES_INVALIDO");
     }
 
     @Test


### PR DESCRIPTION
## Resumo

- `GET /api/v1/resumo` agora aceita `?mes=YYYY-MM` e `?busca=texto` (ambos opcionais)
- Campo `todos` adicionado ao DTO (pendentes + pagos, excluindo cancelados)
- Campo renomeado `mesAtual` → `mes`
- Mês inválido retorna 400 com código `MES_INVALIDO`
- Uploads no S3 agora usam pastas separadas: `pedidos/` para pedidos, `comprovantes/` para comprovantes

## Plano de referência

`docs/plans/BE-16-resumo-com-mes-busca.md`

## Test plan

- [ ] `GET /api/v1/resumo` sem params → retorna mês corrente
- [ ] `GET /api/v1/resumo?mes=2026-05` → retorna dados do mês filtrado
- [ ] `GET /api/v1/resumo?busca=boleto` → filtra por descrição
- [ ] `GET /api/v1/resumo?mes=2026-13` → 400 com `MES_INVALIDO`
- [ ] Enviar pedido via Telegram → confirmar upload em `pedidos/` no S3
- [ ] Enviar comprovante via Telegram → confirmar upload em `comprovantes/` no S3
- [ ] `mvn test` → BUILD SUCCESS (226 testes)

## Impacto no frontend

O campo `mesAtual` no payload JSON foi renomeado para `mes`. FE-12 precisa atualizar o tipo `ResumoMesDTO`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)