### PR TITLE
feat(DEP-01): Route 53 data source + certificado ACM wildcard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,9 +14,12 @@ Bot de finanças para Telegram com frontend web. Monorepo com múltiplos módulo
 
 ## Regra de ouro — isolamento por pasta
 
-- **Claude do back:** toca apenas em `financas_bot_telegram/`, `infra/`, `finbot.service`, `.github/workflows/`
-- **Claude do front:** toca apenas em `frontend/`
-- **Claude de planejamento:** toca apenas em `docs/` — commita direto em `develop`
+O isolamento vale pra **código**. `docs/` é área **compartilhada** — todas as instâncias escrevem ali.
+
+- **Claude do back:** código apenas em `financas_bot_telegram/`, `infra/`, `finbot.service`, `.github/workflows/`
+- **Claude do front:** código apenas em `frontend/`
+- **Claude de planejamento:** commita direto em `develop` e é o **mantenedor** da estrutura de `docs/` (planos, architecture, decisions)
+- **`docs/` é escrita por todos:** qualquer instância adiciona seu status report em `docs/status/` e pode registrar aprendizados em `docs/aprendizado/`. Mudanças estruturais em `docs/plans/`, `docs/architecture/` e `docs/decisions/` ficam com o planejamento.
 - Arquivos da raiz (`CLAUDE.md`, `.gitignore`, `TODO.md`) podem ser editados por qualquer instância quando necessário
 
 ## Estrutura da pasta docs/
@@ -88,6 +91,7 @@ main (protegida — só via PR)
 - **Uma tarefa = uma branch nova** a partir de `develop`, nomeada `feature/<id-tarefa>-<slug>` (ex: `feature/fe-12-resumo-parametrizado`). Não reaproveitar branch guarda-chuva de outra tarefa.
 - **Precedência:** estas convenções prevalecem sobre qualquer plano de tarefa em `docs/plans/`. Um plano **não** deve sobrescrevê-las silenciosamente. Se uma tarefa exigir exceção (ex.: depende de código que só existe numa branch ainda não mergeada), o plano deve declarar `> EXCEÇÃO DE BRANCH:` com a justificativa — e o caminho preferido é mergear a dependência em `develop` antes de começar.
 - PR: branch → `develop` → revisão → merge → PR `develop → main` dispara o deploy
+- **Definição de pronto / pré-merge:** antes de pedir merge, passar pelos gates do `docs/runbooks/PRE-MERGE-CHECKLIST.md` (build, lint, testes, convenção de branch, território) e escrever o status report com frontmatter válido conforme `docs/status/_TEMPLATE.md`. `estado: concluido` só vale com todos os gates ok e zero pendência.
 - Back e front devem fazer merge de `develop` na feature branch regularmente para pegar atualizações de docs
 
 ## CI/CD

--- a/docs/PENDENCIAS-TECNICAS.md
+++ b/docs/PENDENCIAS-TECNICAS.md
@@ -14,8 +14,23 @@ Não confundir com `docs/plans/` (planos de tarefa ativos) nem com a seção "Fa
 
 ## Itens abertos
 
+### `terraform.tfstate` e `.tfstate.backup` commitados em `financas_bot_telegram/infra/`
 
+**Contexto:** `terraform.tfstate`, `terraform.tfstate.backup` e a pasta `.terraform/` estão versionados no repositório. O backend remoto é S3 (`finbot-tfstate-satyans`), então esses arquivos locais são resíduo — a fonte da verdade é o state no S3. Ter o state local versionado cria risco: alguém pode confundir o arquivo local (potencialmente desatualizado) com o state real, ou pior, rodar `terraform` sem ter inicializado o backend S3 e sobrescrever o state remoto.
 
+**Fix sugerido:** adicionar ao `.gitignore` da raiz (ou criar um `financas_bot_telegram/infra/.gitignore`):
+```
+**/.terraform/
+*.tfstate
+*.tfstate.backup
+```
+Depois remover os arquivos do tracking com `git rm --cached`.
+
+**Esforço:** baixo (~10 min).
+
+**Prioridade:** média. Não bloqueia nada hoje (o backend S3 funciona), mas é risco latente de confusão ou corrupção de state.
+
+---
 
 ### Substituir cert self-signed por Let's Encrypt + domínio real
 

--- a/docs/aprendizado/README.md
+++ b/docs/aprendizado/README.md
@@ -43,6 +43,10 @@ Não é documentação de arquitetura (pra isso, `docs/architecture/`) nem plano
 
 - [`git-reset-e-area-de-staging.md`](git-reset-e-area-de-staging.md) — index, modos de `git reset`, lock file
 
+### IA / engenharia de modelos
+
+- [`structured-outputs.md`](structured-outputs.md) — saídas estruturadas de LLM (schema mode, semântica vs. sintaxe), aplicação no parser do bot e no workflow de Claudes
+
 ### Segurança web
 
 - [`cookies-samesite.md`](cookies-samesite.md) — atributo SameSite e proteção CSRF

--- a/docs/aprendizado/structured-outputs.md
+++ b/docs/aprendizado/structured-outputs.md
@@ -1,0 +1,67 @@
+# Structured outputs (saídas estruturadas de LLM)
+
+## Contexto da dúvida
+
+Durante o estudo do livro *AI Engineering: Building Applications with Foundation Models* (Chip Huyen), surgiu a pergunta: dá pra aplicar o conceito de **structured outputs** no fluxo de trabalho do finbot? A discussão aconteceu enquanto o Claude do back executava o DEP-01, num momento de pausa conceitual.
+
+**Escopo do interesse (importante):** a aplicação pretendida é no **fluxo de desenvolvimento com os Claudes** (processo), **não** colocar um LLM dentro da aplicação finbot. A seção do parser do bot fica registrada como aplicação possível-mas-não-agora; o foco é a aplicação meta (workflow).
+
+## Resumo destilado
+
+**Structured output** = forçar o LLM a produzir saída num formato definido (JSON conforme schema, um enum, ou os argumentos de uma função). O ponto central é **onde** a estrutura é imposta, porque a garantia muda:
+
+- **No prompt** ("responda em JSON com X, Y"): barato, mas sem garantia — o modelo escorrega.
+- **Constrained decoding / JSON schema mode**: a API mascara, durante a geração, os tokens que violariam o schema. Garante a **forma**.
+- **Pós-processamento + validação + retry**: valida o que voltou e re-pede se quebrou.
+- **Function/tool calling**: é structured output disfarçado — o modelo devolve "qual função + quais argumentos" num formato fixo.
+
+Princípio que governa tudo: **structured output garante a SINTAXE, não a SEMÂNTICA.** O JSON vem bem-formado; o valor dentro pode estar errado. Em domínio de dinheiro (como o finbot), isso obriga uma camada extra (validação + confirmação humana).
+
+### Aplicação principal: o workflow de Claudes (planejamento ↔ implementadores)
+
+Os artefatos do nosso fluxo são todos "saídas de agente" consumidas por outro agente — e quase todos são texto livre hoje:
+
+- **Planos** (`docs/plans/`): eu produzo, o implementador consome → *input contract*.
+- **Status reports** (`docs/status/`): o implementador produz, eu/humano consumimos → *output contract*.
+- **Avaliações** (`docs/avaliacoes/`): eu produzo revisando o trabalho.
+- **Branch/commit**: já têm convenção = já são um "schema".
+
+Onde structured output se aplica:
+
+**1. Status report como output schema.** Definir frontmatter obrigatório (`tarefa, branch, testes_passando(int), build(ok/fail), lint(ok/fail), veredito, desvios[]`) + corpo livre. Ganhos: (a) vira **agregável** — um script lê todos os `docs/status/*.md` e monta um painel; (b) o schema vira **checklist que força** o implementador a reportar o essencial — campo faltando = violação visível.
+
+**2. O plano é o schema de entrada.** Quanto mais especificado, menor a variância do implementador — igual a um JSON schema reduzir a variância do LLM. O **incidente da FE-12** (branch errada) foi um campo mal-especificado no schema (seção Branch contradizia a convenção): input ambíguo → saída errada. A correção (regra de precedência no CLAUDE.md) foi desambiguar o schema.
+
+**3. CLAUDE.md é o nosso "constrained decoding".** Constrained decoding mascara, na geração, os tokens que violam a gramática. O CLAUDE.md restringe o espaço de comportamento aceitável (território, branch, commit) — a gramática que todo Claude respeita enquanto "gera" trabalho. A regra de precedência adicionada = desambiguação dessa gramática.
+
+**4. Eval do processo: separar sintaxe de semântica.** As avaliações ganham clareza separando **conformidade de processo** (branch certa? status report? 1 commit/tarefa? = sintaxe) de **qualidade do trabalho** (arquitetura, testes, correção = semântica). São falhas de natureza diferente.
+
+### Sintaxe ≠ semântica (vale pro workflow também)
+
+Um status report pode seguir o schema perfeitamente e ainda **mentir** ("226 testes passando" pode ser falso). O schema dá um report *parseável*, não *verdadeiro*. Por isso existem as avaliações e a insistência em **verificação independente** (reler diff, rodar testes de novo) em vez de confiar no autorrelato. No fluxo: o schema é o status report; a validação é a revisão do Claude de planejamento.
+
+### Aplicação secundária (NÃO agora): parser do bot
+
+Registrado pra não perder: o despacho por regex do bot poderia virar parser com structured output (`{ intencao, valor, descricao, tipo, pedido_id, confianca }`, enums garantidos), resolvendo o débito do "comprovante sem `#` vira pedido fantasma". **Mas não agora** — há um único usuário treinado, regex é grátis/determinístico, e seria over-engineering. Gatilho real: entrada natural/variada (EVO-01 WhatsApp, EVO-03 OCR). Padrão correto por ser dinheiro: `schema mode + confiança + confirmação inline`.
+
+### A ponte com validação (Zod / Bean Validation)
+
+Saída de LLM = **input externo não-confiável**, igual a resposta de API ou query param. "Valide na fronteira com um schema" (que a avaliação do front cobrou via Zod) é a mesma disciplina de validar structured output antes de confiar. O schema não dispensa validação — dá o formato pra validar contra.
+
+## Pontos-chave
+
+- Structured output pode ser imposto em 4 lugares: prompt (fraco), constrained decoding/JSON schema mode (garante forma), validação+retry, function/tool calling.
+- **Garante sintaxe, não semântica** — vale tanto pra LLM quanto pro workflow: um status report schema-válido ainda pode mentir.
+- **Aplicação principal = o workflow de Claudes**, não o produto: planos = schema de entrada; status reports = output schema (agregável + checklist forçado); CLAUDE.md = "constrained decoding" do comportamento; avaliação deve separar conformidade de processo (sintaxe) de qualidade (semântica).
+- O incidente da FE-12 = campo ambíguo no "schema" (Branch) → saída errada; fix = desambiguar a gramática (precedência no CLAUDE.md).
+- Verificação independente > autorrelato: o schema dá report parseável, a revisão dá verdade.
+- Aplicação secundária (parser do bot) fica pra quando a entrada virar natural/variada (EVO-01); hoje regex resolve, trocar é over-engineering.
+- Saída de LLM = input não-confiável → **sempre validar na fronteira** (mesma lógica do Zod/Bean Validation).
+
+## Pra aprofundar
+
+- Constrained/guided decoding na prática: bibliotecas como Outlines, Guidance, ou o "structured outputs" nativo da OpenAI (JSON Schema) e o tool use da Anthropic.
+- Trade-off latência/custo/determinismo de LLM vs. parser tradicional.
+- Human-in-the-loop e design de confirmação pra ações de alto risco (dinheiro).
+- Evals de structured output: medir taxa de schema-válido **e** taxa de acerto semântico separadamente.
+- Relação com `react-tanstack-query.md` e o débito de validação Zod (validação de fronteira).

--- a/docs/runbooks/PRE-MERGE-CHECKLIST.md
+++ b/docs/runbooks/PRE-MERGE-CHECKLIST.md
@@ -1,0 +1,55 @@
+# Checklist de pré-merge (gates verificáveis)
+
+Define a **definição de pronto** de qualquer tarefa BE/FE/DEP antes de mergear em `develop`. Cada gate é **machine-checkable**: tem um comando e uma condição de passagem. Os gates aqui mapeiam 1:1 com o bloco `gates:` do frontmatter do status report (`docs/status/_TEMPLATE.md`).
+
+Conceito: o status report é um *output schema* (forma garantida, parseável). Este checklist é a *validação* desse output — porque schema válido não garante verdade (um report pode dizer `testes: ok` sem que seja). O Claude de planejamento (ou um script) confere os gates contra a realidade antes do merge.
+
+## Definição de pronto
+
+`estado: concluido` no frontmatter só é válido quando **todos os gates relevantes** estão `ok` (ou `na` quando não se aplicam) **e** `pendencias_humano: 0`. Caso contrário, o estado é `parcial` (entregou parte) ou `bloqueado` (esperando decisão/humano).
+
+## Gates
+
+| Gate (campo no frontmatter) | Como verificar | Passa quando |
+|---|---|---|
+| `build` | Back: `./mvnw -q -DskipTests package` · Front: `npm run build` | Sai com código 0, sem erro de compilação/TS |
+| `lint` | Front: `npm run lint` · Back: `na` (não há linter configurado) | Sem erros. `na` quando a stack não tem linter |
+| `testes` + `testes_total` + `testes_novos` | Back: `./mvnw test` · Front: `npm test` | Todos verdes. Anotar o total e quantos foram adicionados nesta tarefa |
+| `branch_convencao` | `git rev-parse --abbrev-ref HEAD` e `git merge-base --is-ancestor origin/develop HEAD` | Nome bate `^feature/(be\|fe\|dep\|fix\|hotfix\|evo)-\d+[a-z]?-` **e** saiu de `develop` (develop é ancestral). Ver regra de branch no CLAUDE.md |
+| `territorio` | `git diff --name-only origin/develop...HEAD` | Todos os caminhos alterados estão dentro do território da instância (ver tabela abaixo) |
+
+### Territórios (pra o gate `territorio`)
+
+Isolamento vale pra **código**. `docs/` é compartilhada — toda instância pode escrever ali (status report próprio, aprendizados). Mudança estrutural em `docs/plans/`, `docs/architecture/`, `docs/decisions/` é do planejamento.
+
+| Instância (`responsavel`) | Caminhos de código permitidos | + sempre |
+|---|---|---|
+| `claude-back` | `financas_bot_telegram/`, `infra/`, `finbot.service`, `.github/workflows/` | `docs/` |
+| `claude-front` | `frontend/` | `docs/` |
+| `claude-plan` | — | `docs/` (mantenedor da estrutura) |
+| qualquer | arquivos da raiz (`CLAUDE.md`, `.gitignore`, `TODO.md`) quando necessário | — |
+
+O gate `territorio` falha quando uma instância altera **código fora** do seu território (ex.: o front mexendo em `financas_bot_telegram/`). Mudança em `docs/` nunca dispara o gate.
+
+## Checklist operacional (rodar antes de abrir PR / pedir merge)
+
+- [ ] `build` verde
+- [ ] `lint` verde (ou `na`)
+- [ ] `testes` verdes; `testes_total` e `testes_novos` preenchidos
+- [ ] Todo componente/classe com lógica não-trivial tem ao menos 1 teste (regra do CLAUDE.md)
+- [ ] `branch_convencao` ok (nome correto + saiu de develop)
+- [ ] `territorio` ok (não vazou pra fora da pasta da instância)
+- [ ] Status report criado em `docs/status/<TASK-ID>-*.md` com frontmatter válido
+- [ ] `desvios` e `pendencias_humano` no frontmatter batem com as seções em prosa
+- [ ] `estado` coerente com os gates (só `concluido` se tudo ok e sem pendência)
+- [ ] **Não** fez push pra `develop` — parou pra revisão (salvo instrução explícita)
+
+## Agregação (o ganho de ter schema)
+
+Como o frontmatter é YAML parseável, dá pra montar um painel do projeto sem esforço — um script lê todos os `docs/status/*.md`, extrai o frontmatter e responde coisas como: quais tarefas estão `bloqueado`, quantos `desvios` abertos por área, soma de `testes_total`, quais branches fogem da convenção. Não precisa existir agora; o schema só deixa a porta aberta pra isso.
+
+## Relação com outros docs
+
+- Schema do status report: `docs/status/_TEMPLATE.md`
+- Convenção de branch e territórios: `CLAUDE.md` (seção "Fluxo de branches" e "Regra de ouro")
+- Por que validar mesmo com schema válido: `docs/aprendizado/structured-outputs.md` (sintaxe ≠ semântica)

--- a/docs/status/DEP-01.md
+++ b/docs/status/DEP-01.md
@@ -1,0 +1,56 @@
+# Status — DEP-01: Hosted Zone (Route 53) + Certificado ACM
+
+**Branch:** `feature/dep-01-route53-zone-acm`
+**Data de execução:** 2026-05-26
+**Executor:** Claude do back
+**Estado:** concluído — aguardando revisão antes de mergear em develop
+
+---
+
+## Recursos criados
+
+| Recurso | ID / ARN |
+|---|---|
+| `data.aws_route53_zone.principal` | `Z06950183U96CYLZM2MVU` (referência — não criado) |
+| `aws_acm_certificate.principal` | `arn:aws:acm:us-east-1:776658251579:certificate/5481752d-d925-48ed-a7fd-47720a75a098` |
+| `aws_route53_record.acm_validation["satyansaita.com"]` | CNAME de validação na zona |
+| `aws_route53_record.acm_validation["*.satyansaita.com"]` | CNAME de validação na zona (mesmo registro — Route 53 deduplicou) |
+| `aws_acm_certificate_validation.principal` | Validação concluída em ~34s |
+
+## Outputs
+
+```
+acm_certificate_arn = "arn:aws:acm:us-east-1:776658251579:certificate/5481752d-d925-48ed-a7fd-47720a75a098"
+route53_zone_id     = "Z06950183U96CYLZM2MVU"
+```
+
+## Checagens realizadas
+
+- [x] `terraform init` — backend S3 confirmado (`finbot-tfstate-satyans`, `prod/terraform.tfstate`)
+- [x] `terraform plan` antes do apply — apenas adições (4 to add, 0 to change, 0 to destroy)
+- [x] `terraform apply` — concluído sem erro (4 added)
+- [x] Certificado ACM com status **ISSUED** (validação DNS completou em ~1s após os registros serem criados)
+- [x] `terraform output acm_certificate_arn` e `route53_zone_id` — valores válidos
+- [x] Segundo `terraform plan` — **No changes** (idempotência confirmada)
+
+## Desvios em relação ao plano
+
+### Desvio 1 — Drift de AMI na EC2 (pré-existente, não do DEP-01)
+
+O primeiro `terraform plan` mostrou `aws_instance.finbot_app` marcado para **destroy + replace** por drift de AMI (`ami-0e6d903c989c08b79` → `ami-00f40869bea0a58a3`). A causa é o `data.aws_ami.amazon_linux_2023` com `most_recent = true` em `ec2.tf` — o AWS publicou uma AMI nova depois que a EC2 foi criada.
+
+**Resolução aprovada pelo humano:** adicionado `lifecycle { ignore_changes = [ami] }` em `aws_instance.finbot_app` no `ec2.tf`. A EC2 de prod não foi recriada. O fix é incluído nesta branch.
+
+### Desvio 2 — Domínio não estava documentado
+
+O domínio `satyansaita.com` não constava em nenhum plano ou doc (DEP-00 não tinha status report). Execução pausada e domínio confirmado pelo humano antes de prosseguir.
+
+## Pendências geradas
+
+- `docs/PENDENCIAS-TECNICAS.md` atualizado com item sobre `terraform.tfstate` commitado (ver seção correspondente).
+
+## Próximo passo
+
+DEP-02 (CloudFront + S3 para o frontend) consome:
+- `acm_certificate_arn` = `arn:aws:acm:us-east-1:776658251579:certificate/5481752d-d925-48ed-a7fd-47720a75a098`
+- `route53_zone_id` = `Z06950183U96CYLZM2MVU`

--- a/docs/status/_TEMPLATE.md
+++ b/docs/status/_TEMPLATE.md
@@ -1,74 +1,67 @@
-# [TASK-ID] — Título curto da tarefa
-
-> **Não edite este arquivo.** Copie pra `<TASK-ID>-titulo-curto.md` (ex: `BE-05-listar-pedidos.md`) e preencha lá.
-
+---
+# ─── Frontmatter (schema obrigatório — parseável por script) ───
+# Tipos e valores válidos estão em docs/runbooks/PRE-MERGE-CHECKLIST.md
+task: BE-05                       # ^(BE|FE|DEP|FIX|HOTFIX|EVO)-\d+[a-z]?$
+titulo: "Listar pedidos com filtros"
+data: 2026-05-23                  # YYYY-MM-DD
+branch: feature/be-05-listar-pedidos
+responsavel: claude-back          # claude-back | claude-front | claude-plan | humano
+estado: concluido                 # concluido | parcial | bloqueado
+gates:
+  build: ok                       # ok | fail | na
+  lint: ok                        # ok | fail | na
+  testes: ok                      # ok | fail | na
+  testes_total: 67                # int — total de testes que rodaram
+  testes_novos: 12                # int — testes adicionados nesta tarefa
+  branch_convencao: ok            # ok | fail — bate com feature/<id>-<slug> a partir de develop
+  territorio: ok                  # ok | fail — tocou só na pasta do território da instância
+commits:
+  - 18b3f92
+pr: null                          # URL do PR ou null
+desvios: 0                        # int — quantidade de desvios do plano (detalhar na seção abaixo)
+pendencias_humano: 0              # int — decisões aguardando humano (detalhar na seção abaixo)
 ---
 
-**Data:** YYYY-MM-DD
-**Branch:** feature/...
-**Commit/PR:** abc1234 (ou link do PR)
-**Responsável (instância):** Claude Code (IntelliJ) / Claude Code (CLI) / humano
+# [TASK-ID] — Título curto da tarefa
+
+> **Não edite este arquivo.** Copie pra `<TASK-ID>-titulo-curto.md` (ex: `BE-05-listar-pedidos.md`), preencha o frontmatter acima e as seções abaixo.
+>
+> **Regra de "concluído":** `estado: concluido` só é válido se TODOS os gates relevantes estiverem `ok` (ou `na` quando não se aplica) e `pendencias_humano: 0`. Se algum gate falhar ou houver pendência, use `parcial` ou `bloqueado`. Ver `docs/runbooks/PRE-MERGE-CHECKLIST.md`.
 
 ---
 
 ## O que foi feito
 
-Descreva em prosa curta o que efetivamente entrou no commit. Não é pra repetir o critério de aceitação — é pra contar a realidade.
-
-Exemplo:
-- Criei a migration V2 conforme planejado, com o ajuste citado abaixo.
-- Validei `EXPLAIN` nos índices novos: ambos cobrindo.
-- Apliquei em dev sem erro.
+Prosa curta do que efetivamente entrou no commit. Não repita o critério de aceitação — conte a realidade.
 
 ---
 
 ## Desvios do plano
 
-Se você fez algo diferente do que estava em `plans/`, documente aqui. Cada desvio precisa de uma justificativa.
-
-Exemplo:
-- O plano pedia `data_pedido DATE NOT NULL DEFAULT (CURRENT_DATE)` mas o MySQL 8.0.13+ não aceita expressão como default em DATE — usei trigger ou backfill explícito.
-- A coluna `tipo` foi nomeada `tipo_pagamento` em vez de `tipo` porque já existia uma coluna `tipo` no schema legado.
-
-Se não houve desvio, escreva "Nenhum.".
+Cada desvio precisa de justificativa. O número aqui deve bater com `desvios:` no frontmatter. Se não houve, escreva "Nenhum." e mantenha `desvios: 0`.
 
 ---
 
 ## Decisões tomadas durante a execução
 
-Decisões locais (que não mereceriam um ADR, mas que vale registrar). Geralmente envolvem nome de variável, escolha de helper, organização de arquivo.
-
-Exemplo:
-- Coloquei o mapper `PedidoEntity ↔ Pedido` na pasta `infra/persistence/mapper/` em vez de junto da entity, pra ficar mais isolado.
-- Optei por `record` Java em vez de classe pra os DTOs — menos boilerplate.
+Decisões locais (nome de variável, escolha de helper, organização de arquivo) que não merecem ADR mas vale registrar.
 
 ---
 
 ## Decisões pendentes (esperando humano)
 
-Se você bateu em algo que precisa de decisão de produto e não tem como inferir do plano + architecture, registre aqui e **não prossiga**.
-
-Exemplo:
-- O endpoint `/api/v1/resumo` deveria considerar pedidos com `data_pedido` no mês atual ou pedidos com `data_pagamento` no mês atual? O plano não especifica. Aguardando confirmação.
-
-Se não há nada pendente, escreva "Nenhuma — tarefa fechada.".
+Se bateu em algo que precisa de decisão de produto e não dá pra inferir do plano + architecture, registre aqui e **não prossiga** (use `estado: bloqueado`). O número de itens deve bater com `pendencias_humano:`. Se não há nada, escreva "Nenhuma — tarefa fechada." e mantenha `pendencias_humano: 0`.
 
 ---
 
 ## Próximos passos / observações pro próximo
 
-Coisas que o próximo implementador (ou o planejador) precisa saber. Útil pra atalhos e gotchas que descobriu.
-
-Exemplo:
-- A tarefa BE-06 vai precisar do `requisitanteId` no contexto da request — já deixei o filter de auth preparado pra isso.
-- Notei que o teste de integração demora 30s pra subir Testcontainers — talvez vale otimizar reuso entre testes em uma tarefa futura.
+Gotchas e atalhos que o próximo implementador (ou o planejador) precisa saber.
 
 ---
 
 ## Arquivos criados/modificados
 
-Lista resumida (não precisa exaustiva — git diff já tem isso). Útil pra o planejador escanear rápido.
+Lista resumida (o git diff tem o exaustivo). Útil pro planejador escanear rápido.
 
-- `src/main/resources/db/migration/V2__add_requisitante_dates_categoria_auth.sql` (novo)
-- `domain/Pedido.java` (modificado: campos novos)
-- `infra/persistence/PedidoEntity.java` (modificado)
+- `caminho/do/arquivo.ext` (novo | modificado: motivo curto)

--- a/financas_bot_telegram/infra/acm.tf
+++ b/financas_bot_telegram/infra/acm.tf
@@ -1,0 +1,35 @@
+# Certificado para o apex + wildcard (cobre api.<domínio>, www, etc).
+# Provider default já é us-east-1 — requisito do CloudFront.
+resource "aws_acm_certificate" "principal" {
+  domain_name               = var.domain_name
+  subject_alternative_names = ["*.${var.domain_name}"]
+  validation_method         = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Registros de validação DNS na hosted zone (um por domínio/SAN; o Route 53 dedupe iguais).
+resource "aws_route53_record" "acm_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.principal.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  zone_id         = data.aws_route53_zone.principal.zone_id
+  name            = each.value.name
+  type            = each.value.type
+  records         = [each.value.record]
+  ttl             = 60
+  allow_overwrite = true
+}
+
+# Espera a validação concluir antes de marcar o cert como pronto.
+resource "aws_acm_certificate_validation" "principal" {
+  certificate_arn         = aws_acm_certificate.principal.arn
+  validation_record_fqdns = [for r in aws_route53_record.acm_validation : r.fqdn]
+}

--- a/financas_bot_telegram/infra/dev.tfvars
+++ b/financas_bot_telegram/infra/dev.tfvars
@@ -2,3 +2,4 @@
 
 env               = "dev"
 db_instance_class = "db.t4g.micro"
+domain_name       = "satyansaita.com"

--- a/financas_bot_telegram/infra/dns.tf
+++ b/financas_bot_telegram/infra/dns.tf
@@ -1,0 +1,5 @@
+# Zona já existe (criada pelo registro do domínio no Route 53). Referenciar, não criar.
+data "aws_route53_zone" "principal" {
+  name         = var.domain_name
+  private_zone = false
+}

--- a/financas_bot_telegram/infra/ec2.tf
+++ b/financas_bot_telegram/infra/ec2.tf
@@ -33,6 +33,11 @@ resource "aws_instance" "finbot_app" {
   EOF
 
   tags = { Name = "finbot-${var.env}-ec2-app" }
+
+  # AMI atualizada pelo AWS após o provisionamento inicial — ignorar drift pra não recriar instância de prod.
+  lifecycle {
+    ignore_changes = [ami]
+  }
 }
 
 # Elastic IP — endereço fixo para configurar o webhook do Telegram

--- a/financas_bot_telegram/infra/outputs.tf
+++ b/financas_bot_telegram/infra/outputs.tf
@@ -1,0 +1,9 @@
+output "route53_zone_id" {
+  description = "Zone ID da hosted zone — usado por DEP-02/03 nos registros alias"
+  value       = data.aws_route53_zone.principal.zone_id
+}
+
+output "acm_certificate_arn" {
+  description = "ARN do cert validado — usado pelo CloudFront (DEP-02)"
+  value       = aws_acm_certificate_validation.principal.certificate_arn
+}

--- a/financas_bot_telegram/infra/prod.tfvars
+++ b/financas_bot_telegram/infra/prod.tfvars
@@ -3,3 +3,4 @@ ec2_instance_type = "t4g.micro"
 key_pair_name     = "finbot-prod-key"  # nome do key pair criado no console EC2
 my_ip             = "189.4.122.91/32"
 s3_images_bucket  = "bot-financas-pagamentos-satyan"
+domain_name       = "satyansaita.com"

--- a/financas_bot_telegram/infra/variables.tf
+++ b/financas_bot_telegram/infra/variables.tf
@@ -24,3 +24,8 @@ variable "s3_images_bucket" {
   type        = string
   default     = "bot-financas-pagamentos-satyan"
 }
+
+variable "domain_name" {
+  description = "Domínio raiz registrado no Route 53 (ex: satyansaita.com)"
+  type        = string
+}


### PR DESCRIPTION
## O que muda

- `dns.tf`: referencia a hosted zone `satyansaita.com` via `data source` (zona criada pelo registro do domínio no Route 53 — não recriada pelo Terraform)
- `acm.tf`: certificado ACM para apex + wildcard (`satyansaita.com` + `*.satyansaita.com`) com validação DNS automática via registros CNAME na hosted zone
- `outputs.tf`: expõe `acm_certificate_arn` e `route53_zone_id` — contrato para DEP-02 (CloudFront) e DEP-03 (registro `api.`)
- `variables.tf` + `prod.tfvars` + `dev.tfvars`: adiciona `domain_name = "satyansaita.com"`
- `ec2.tf`: `lifecycle { ignore_changes = [ami] }` para suprimir drift de AMI pré-existente que causaria replace da EC2 de prod no próximo apply

## Outputs gerados

```
acm_certificate_arn = "arn:aws:acm:us-east-1:776658251579:certificate/5481752d-d925-48ed-a7fd-47720a75a098"
route53_zone_id     = "Z06950183U96CYLZM2MVU"
```

## Validação

- `terraform init` → backend S3 confirmado
- `terraform plan` → 4 to add, 0 to change, 0 to destroy
- `terraform apply` → 4 added, cert **ISSUED**
- Segundo `terraform plan` → **No changes** (idempotência confirmada)

## Desvios

- **Drift de AMI da EC2:** pré-existente; resolvido com `lifecycle { ignore_changes = [ami] }` após aprovação do humano
- **Domínio não documentado:** execução pausada até confirmar `satyansaita.com`

## Pendência anotada

`docs/PENDENCIAS-TECNICAS.md`: `terraform.tfstate` e `.terraform/` commitados na pasta de infra — sugerido fix com `.gitignore` em task separada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)