### PR TITLE
fix: normaliza fim de linha pra LF via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+# Fim de linha: normaliza tudo pra LF no working tree.
+# Alvo de deploy é Linux; Terraform/bash/Spring preferem LF, e o Terraform lê
+# user_data byte a byte — CRLF causa drift. Cobre .tf, .tfvars, .sh, .properties,
+# .ts, .tsx, .java, .yml, .md, etc. via a regra global abaixo.
+* text=auto eol=lf
+
+# Binários — git nunca converte
+*.png      binary
+*.jpg      binary
+*.jpeg     binary
+*.gif      binary
+*.ico      binary
+*.jar      binary
+*.p12      binary
+*.keystore binary
+*.woff     binary
+*.woff2    binary
+
+# Arquivos que (se existirem) precisam de CRLF no Windows
+*.bat text eol=crlf
+*.cmd text eol=crlf

--- a/docs/aprendizado/git-line-endings-crlf-lf.md
+++ b/docs/aprendizado/git-line-endings-crlf-lf.md
@@ -1,0 +1,47 @@
+# Fim de linha no git: CRLF vs LF, .gitattributes e renormalização
+
+## Contexto da dúvida
+
+Veio da revisão do DEP-02: o `terraform plan` mostrava drift recorrente de `user_data` da EC2 (update in-place) causado por fim de linha. Já tínhamos visto antes o "diff-noise" (toda linha do arquivo aparecendo como alterada). A pergunta foi entender a fundo o problema e a cura (`.gitattributes`).
+
+## Resumo destilado
+
+### O problema
+Windows marca fim de linha com **CRLF** (`\r\n`), Unix/Mac com **LF** (`\n`) — bytes invisíveis no editor, mas reais no arquivo. O git tem `core.autocrlf` (config **por máquina**) que decide se converte. Como cada dev pode ter config diferente e o deploy é Linux, o mesmo arquivo **oscila** entre CRLF e LF conforme quem commita. Dois sintomas:
+
+1. **Diff-noise:** quando o fim de linha muda, **toda linha** aparece como alterada (assinatura "N add / N del" em arquivo não mudado). Polui review, blame, histórico.
+2. **Drift no Terraform:** `user_data` é montado do conteúdo de arquivo **byte a byte**. CRLF muda o hash → plan mostra `update in-place` que reaparece sempre. Inofensivo (metadata-only), mas mascara mudanças reais.
+
+### A solução: `.gitattributes`
+Arquivo **commitado no repo** que declara, por padrão de caminho, como o git trata fim de linha — **independente do `core.autocrlf` local**. Tira a inconsistência: passa a valer igual pra todos.
+
+- Regra usada: `* text=auto eol=lf` → força **LF no working tree** pra todo arquivo de texto. Correto aqui porque o alvo é Linux e o working-tree em LF mantém o hash do `user_data` estável. Editores modernos lidam com LF no Windows numa boa.
+- Binários marcados como `binary` (git nunca converte): `*.png`, `*.jar`, `*.p12`, etc.
+- `*.bat`/`*.cmd` → `eol=crlf` (se existirem; Windows precisa).
+
+### O pulo do gato: renormalizar
+`.gitattributes` **só vale dali pra frente** — não conserta o que já está commitado. Pra limpar o CRLF existente:
+
+```
+git add .gitattributes
+git add --renormalize .   # reescreve os blobs com o EOL normalizado
+git commit -m "fix: normaliza fim de linha via .gitattributes"
+```
+
+Gera um diff grande (esperado — só fim de linha) → fazer em **commit único e dedicado**, com o repo "quieto" (sem feature branches abertas, pra evitar conflito de EOL no merge).
+
+## Pontos-chave
+
+- **CRLF** (Windows) ≠ **LF** (Unix). Misturar = diff-noise + drift de hash (Terraform `user_data`).
+- `core.autocrlf` é **por máquina** → inconsistente entre devs. `.gitattributes` é **do repo** → consistente pra todos.
+- `* text=auto eol=lf` força LF no working tree (certo quando o alvo é Linux e ferramentas leem bytes).
+- Marcar binários como `binary` pra git nunca convertê-los.
+- `.gitattributes` não age retroativamente → **`git add --renormalize .`** + commit único pra limpar o legado.
+- Fazer com o repo quieto (sem branches abertas) pra evitar conflito de EOL.
+
+## Pra aprofundar
+
+- `git ls-files --eol` — inspeciona o EOL no índice (`i/lf`) e no working tree (`w/`).
+- Diferença entre `text=auto` (normaliza no repo, EOL nativo no checkout) e `text=auto eol=lf` (força LF também no working tree).
+- Relação com `git-reset-e-area-de-staging.md` (a mesma área de staging onde o renormalize age).
+- `.editorconfig` como camada complementar (configura o editor, não o git).

--- a/docs/plans/FIX-gitattributes-eol.md
+++ b/docs/plans/FIX-gitattributes-eol.md
@@ -1,0 +1,92 @@
+# FIX — Normalizar fim de linha (.gitattributes) e eliminar drift CRLF/LF
+
+## Contexto
+
+Diffs com line-ending oscilando (CRLF↔LF) já geraram ruído (a assinatura "N adicionadas / N removidas" em arquivos não alterados de fato) e, no DEP-02, **drift recorrente de `user_data` da EC2** no `terraform plan` (update in-place metadata-only que reaparece a cada plan). Causa: arquivos commitados ora com CRLF (Windows) ora com LF, sem regra consistente. O Terraform lê o `user_data` byte a byte, então o fim de linha muda o hash.
+
+## Objetivo
+
+Fixar fim de linha como **LF** no working tree pra todo o repo via `.gitattributes` (commitado, vale pra todos independente do `core.autocrlf` local) e **renormalizar** os arquivos já versionados pra limpar o CRLF existente.
+
+## Branch
+
+`fix/gitattributes-eol` — nova, a partir de `develop`.
+
+> **EXCEÇÃO DE TERRITÓRIO:** este fix é uma normalização **repo-wide** — o `git add --renormalize` reescreve fins de linha em arquivos de `frontend/`, `financas_bot_telegram/`, `docs/` e raiz. Por natureza ele cruza territórios; não dá pra escopar numa pasta só. Justificativa registrada conforme a regra de precedência do CLAUDE.md. Por isso deve ser um **commit único e dedicado**, sem misturar com mudança funcional.
+
+## Pré-condição (timing)
+
+Fazer **agora**, enquanto `develop` é a única linha ativa (front e back já mergeados, DEP-03 não começou). Branches de feature abertas no momento do renormalize tendem a gerar conflito de fim de linha no merge — então o ideal é o repo estar "quieto", que é o caso.
+
+## Passo 1 — Criar `.gitattributes` na raiz do repo
+
+```gitattributes
+# Fim de linha: normaliza tudo pra LF no working tree.
+# Alvo de deploy é Linux; Terraform/bash/Spring preferem LF, e o Terraform lê
+# user_data byte a byte — CRLF causa drift. Cobre .tf, .tfvars, .sh, .properties,
+# .ts, .tsx, .java, .yml, .md, etc. via a regra global abaixo.
+* text=auto eol=lf
+
+# Binários — git nunca converte
+*.png      binary
+*.jpg      binary
+*.jpeg     binary
+*.gif      binary
+*.ico      binary
+*.jar      binary
+*.p12      binary
+*.keystore binary
+*.woff     binary
+*.woff2    binary
+
+# Arquivos que (se existirem) precisam de CRLF no Windows
+*.bat text eol=crlf
+*.cmd text eol=crlf
+```
+
+## Passo 2 — Renormalizar e commitar
+
+Executado **pelo humano no PowerShell** (regra do projeto: git não roda pelo sandbox). Comandos:
+
+```powershell
+git checkout develop
+git pull
+git checkout -b fix/gitattributes-eol
+
+# cria/edita o .gitattributes (passo 1)
+
+git add .gitattributes
+git add --renormalize .
+git status        # confere o que mudou — espere MUITOS arquivos (só fim de linha)
+git commit -m "fix: normaliza fim de linha pra LF via .gitattributes"
+```
+
+> O `git status` vai mostrar muitos arquivos modificados — isso é **esperado** (é só fim de linha). É o motivo de ser um commit isolado.
+
+## Passo 3 — Verificar que o drift sumiu
+
+```powershell
+cd financas_bot_telegram/infra
+terraform plan -var-file=prod.tfvars
+```
+
+- O plan **não** deve mais mostrar o `update in-place` do `aws_instance.finbot_app` por mudança de hash do `user_data`.
+- Opcional: `git ls-files --eol` deve mostrar `i/lf` (LF no índice) pros arquivos de texto.
+
+## Critérios de aceitação
+
+- `.gitattributes` na raiz com as regras acima.
+- Um **único commit** de renormalização (só fim de linha, zero mudança funcional).
+- `terraform plan -var-file=prod.tfvars` limpo quanto ao `user_data` da EC2 (o drift CRLF/LF some). Se sobrar algum outro drift não relacionado, **parar e investigar** antes de aplicar.
+- Nenhum arquivo teve conteúdo funcional alterado (revisar o diff por amostragem: deve ser só fim de linha).
+
+## Não-objetivos
+
+- Não aplicar (`terraform apply`) nada aqui — o fix é só de repo/linha. O plan limpo já é a prova.
+- Não mexer em conteúdo de código.
+
+## Coordenação
+
+- Território: arquivo de raiz (`.gitattributes`) + renormalização repo-wide (exceção declarada acima). Pode ser executado pelo humano direto (são poucos comandos git) ou por uma instância designada — mas o git roda **no PowerShell**, nunca pelo sandbox.
+- Status report em `docs/status/FIX-gitattributes-eol.md` (frontmatter: `gates.build/lint/testes = na`; registrar o resultado do `terraform plan` como evidência do gate).
+- Relacionado: `docs/aprendizado/git-line-endings-crlf-lf.md`.

--- a/docs/status/FIX-gitattributes-eol.md
+++ b/docs/status/FIX-gitattributes-eol.md
@@ -1,0 +1,34 @@
+---
+feature: FIX-gitattributes-eol
+branch: fix/gitattributes-eol
+status: done
+gates:
+  build: na
+  lint: na
+  testes: na
+date: 2026-05-26
+---
+
+# Status — FIX-gitattributes-eol
+
+## O que foi feito
+
+- Criado `.gitattributes` na raiz com `* text=auto eol=lf` (LF no working tree pra todos os arquivos de texto) e marcações binárias para imagens/JARs/keystores.
+- `git add --renormalize .` executado: o índice já estava em LF — nenhum arquivo de texto adicional precisou de renormalização.
+- Working copy do `ec2.tf` atualizada via `git checkout -- financas_bot_telegram/infra/ec2.tf` para forçar LF no disco antes do `terraform plan`.
+
+## Evidência — terraform plan limpo
+
+```
+No changes. Your infrastructure matches the configuration.
+```
+
+O plan foi executado em `financas_bot_telegram/infra/` com `terraform plan -var-file=prod.tfvars`. O `aws_instance.finbot_app` **não aparece mais** como `update in-place` por mudança de hash do `user_data`. Drift CRLF/LF eliminado.
+
+## Observação
+
+`docs/aprendizado/README.md` tinha uma mudança de conteúdo pré-existente (link novo adicionado pelo Claude de planejamento) e foi mantido fora do commit de normalização, conforme instrução do plano ("se houver mudança de conteúdo, PARAR").
+
+## Próximo passo
+
+PR para develop para revisão. Nenhum `terraform apply` necessário — este fix é só de repositório.


### PR DESCRIPTION
## Resumo

- Cria `.gitattributes` na raiz com `* text=auto eol=lf` — força LF no working tree independente do `core.autocrlf` local
- Marca binários (PNG, JPG, JAR, p12, keystore, woff) para nunca converter
- `.bat`/`.cmd` mantidos com CRLF (necessário no Windows)

## Motivação

CRLF/LF oscilante causava drift recorrente de `user_data` da EC2 no `terraform plan` (update in-place metadata-only que reaparecia a cada plan). O Terraform lê o `user_data` byte a byte — qualquer diferença de fim de linha muda o hash.

## Evidência — gate de verificação

```
terraform plan -var-file=prod.tfvars
→ No changes. Your infrastructure matches the configuration.
```

`aws_instance.finbot_app` não aparece mais como update in-place. Drift eliminado.

## Observações

- `git add --renormalize .` confirmou que o índice já estava em LF — nenhum arquivo adicional precisou renormalizar.
- `docs/aprendizado/README.md` tinha mudança de conteúdo pré-existente e foi mantido fora do commit de normalização conforme instrução do plano.
- Commit de normalização é isolado, zero mudança funcional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)