### PR TITLE
feat(CI-01): gate de CI no PR pra develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,75 @@
+name: CI Gate (develop)
+
+on:
+  pull_request:
+    branches: [develop]
+  push:
+    branches:
+      - 'feature/**'
+      - 'fix/**'
+      - 'hotfix/**'
+
+jobs:
+  # Detecta o que mudou pra rodar só o necessário
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'financas_bot_telegram/**'
+            frontend:
+              - 'frontend/**'
+
+  branch-name:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validar convenção de branch
+        run: |
+          REF="${{ github.head_ref || github.ref_name }}"
+          echo "Branch: $REF"
+          if [[ ! "$REF" =~ ^(feature|fix|hotfix)/[a-z0-9]+(-[a-z0-9.]+)*$ ]]; then
+            echo "::error::Branch '$REF' fora da convenção (feature/<slug>, fix/<slug>, hotfix/<slug>)."
+            exit 1
+          fi
+
+  backend:
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Testes (back)
+        run: mvn test -f financas_bot_telegram/pom.xml
+      - name: Build JAR (back)
+        run: mvn package -DskipTests -f financas_bot_telegram/pom.xml
+
+  frontend:
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test
+      - run: npm run build

--- a/docs/status/CI-01.md
+++ b/docs/status/CI-01.md
@@ -1,0 +1,53 @@
+---
+task: CI-01
+titulo: "Gate de CI no PR pra develop"
+data: 2026-05-26
+branch: feature/ci-01-gate-pr-develop
+responsavel: claude-back
+estado: concluido
+gates:
+  build: ok
+  lint: na
+  testes: ok
+  testes_total: na
+  testes_novos: na
+  branch_convencao: ok
+  territorio: ok
+commits:
+  - 23bc3d0
+  - ba19455
+pr: null
+desvios: 1
+pendencias_humano: 0
+---
+
+# CI-01 — Gate de CI no PR pra develop
+
+## O que foi feito
+
+- Criado `.github/workflows/ci.yml` com 4 jobs: `changes` (paths-filter), `branch-name` (regex de convenção), `backend` (mvn test + mvn package), `frontend` (npm ci + lint + test + build).
+- O workflow dispara em `pull_request` pra `develop` e em `push` em `feature/**`, `fix/**`, `hotfix/**`.
+- Testado de verdade: push na branch `feature/ci-01-gate-pr-develop` disparou o run `26470912614` — todos os 4 jobs verdes (run: https://github.com/SSteringS/financas_bot_telegram/actions/runs/26470912614).
+
+## Desvios do plano
+
+1. **Compilação de teste quebrada (pré-existente):** `PedidoControllerListarTest.java:41` passava `StatusPedido.PAGO` onde o controller agora espera `String` (mudança feita em sessão anterior para fix `status=todos`). O CI expôs o problema. Corrigido na mesma branch (commit `ba19455`): substituído `StatusPedido.PAGO` por `"PAGO"`. A asserção `filtro.status()).isEqualTo(StatusPedido.PAGO)` permanece correta pois `parseStatus("PAGO")` retorna o enum.
+
+## Decisões tomadas durante a execução
+
+- Mantive exatamente o yaml do plano, sem ajuste de versão de actions — os avisos de depreciação do Node.js 20 (actions/checkout@v4, setup-java@v4, setup-node@v4, dorny/paths-filter@v3) são informativos, não bloqueantes, e a data de remoção é setembro/2026.
+
+## Decisões pendentes (esperando humano)
+
+Nenhuma — tarefa fechada.
+
+## Próximos passos / observações pro próximo
+
+- Os avisos de "Node.js 20 actions are deprecated" vão aparecer nos runs até que os actions sejam atualizados para v5 (ou a flag `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` seja setada). Não bloqueante por ora.
+- Fase 2 do CI (validar presença de `docs/status/<TASK>.md` com frontmatter) fica como follow-up separado (`CI-02`?).
+- O commit `ba19455` toca em `financas_bot_telegram/src/test/` — território correto do back.
+
+## Arquivos criados/modificados
+
+- `.github/workflows/ci.yml` (novo: workflow de CI gate)
+- `financas_bot_telegram/src/test/java/.../adapters/in/rest/pedido/PedidoControllerListarTest.java` (modificado: parâmetro `StatusPedido.PAGO` → `"PAGO"` para refletir mudança de tipo no controller)

--- a/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/rest/pedido/PedidoControllerListarTest.java
+++ b/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/rest/pedido/PedidoControllerListarTest.java
@@ -38,7 +38,7 @@ class PedidoControllerListarTest {
         PaginaDTO<PedidoResumoDTO> pagina = new PaginaDTO<>(List.of(), 0, 0, 20, 0);
         when(listarUseCase.listar(any(), any())).thenReturn(pagina);
 
-        controller.listar(StatusPedido.PAGO, null, null, null, "energia", 0, 20, 1L);
+        controller.listar("PAGO", null, null, null, "energia", 0, 20, 1L);
 
         ArgumentCaptor<ListarPedidosFiltro> captor = ArgumentCaptor.forClass(ListarPedidosFiltro.class);
         verify(listarUseCase).listar(captor.capture(), any());


### PR DESCRIPTION
## Resumo

- Cria `.github/workflows/ci.yml` com 4 jobs: `changes` (paths-filter por pasta), `branch-name` (validação de convenção), `backend` (mvn test + package), `frontend` (npm lint + test + build)
- Dispara em `pull_request → develop` e em `push` em `feature/**`, `fix/**`, `hotfix/**`
- Gate informativo por ora (branch protection adiada — decisão 2026-05-26)

## Evidência de CI verde

Run [26470912614](https://github.com/SSteringS/financas_bot_telegram/actions/runs/26470912614) — todos os 4 jobs verdes:
- `changes` ✓ (4s)
- `branch-name` ✓ (3s)
- `backend` ✓ (1m16s)
- `frontend` ✓ (31s)

## Desvio corrigido

Primeiro run falhou: `PedidoControllerListarTest.java:41` passava `StatusPedido.PAGO` onde o controller espera `String` (consequência do fix `status=todos` de sessão anterior). Corrigido no commit `ba19455`.

## Não tocado

`deploy.yml` intacto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)