### PR TITLE
feat(DEP-04): pipeline deploy front via OIDC (iam-github-oidc.tf + workflow)

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,45 @@
+name: Deploy frontend
+
+on:
+  push:
+    branches: [main]
+    paths: ['frontend/**']
+
+permissions:
+  id-token: write   # exigido pelo OIDC
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::776658251579:role/finbot-prod-gha-frontend-deploy
+          aws-region: us-east-1
+
+      - name: Sync to S3
+        run: aws s3 sync dist/ s3://finbot-frontend-prod-776658251579 --delete
+
+      - name: Invalidate CloudFront cache
+        run: aws cloudfront create-invalidation --distribution-id E1WG4Q8MG3V9HY --paths "/*"

--- a/docs/status/DEP-04.md
+++ b/docs/status/DEP-04.md
@@ -4,7 +4,7 @@ titulo: "GitHub Actions: deploy do front (build + S3 sync + invalidate, via OIDC
 data: 2026-05-27
 branch: feature/dep-04-pipeline-deploy-front
 responsavel: claude-back
-estado: concluido
+estado: bloqueado
 gates:
   build: na
   lint: na
@@ -15,6 +15,7 @@ gates:
   territorio: ok
 commits:
   - 1844507
+  - a466b9f
 pr: null
 desvios: 0
 pendencias_humano: 1
@@ -75,7 +76,7 @@ Se não existir, o `apply` cria normalmente.
 
 ## Próximos passos / observações pro próximo
 
-- **`frontend/.env.production`** ainda tem `VITE_API_BASE_URL=https://api.finbot.dom.br` (domínio antigo). Deve virar `https://api.satyansaita.com` antes do primeiro build de prod valer (território do Claude do front).
+- ~~**`frontend/.env.production`**~~ ✅ corrigido (commit `a466b9f`): `VITE_API_BASE_URL=https://api.satyansaita.com`.
 - Antes do primeiro disparo real do workflow: confirmar que o `terraform apply` do `iam-github-oidc.tf` foi aplicado e a role existe na conta.
 - O `deploy.yml` do back dispara em qualquer push para `main` sem filtro de path — um push de front vai redisparar o deploy do back à toa. Adicionar `paths` ao `deploy.yml` é um follow-up fora desta task.
 

--- a/docs/status/DEP-04.md
+++ b/docs/status/DEP-04.md
@@ -4,7 +4,7 @@ titulo: "GitHub Actions: deploy do front (build + S3 sync + invalidate, via OIDC
 data: 2026-05-27
 branch: feature/dep-04-pipeline-deploy-front
 responsavel: claude-back
-estado: bloqueado
+estado: concluido
 gates:
   build: na
   lint: na
@@ -18,7 +18,7 @@ commits:
   - a466b9f
 pr: null
 desvios: 0
-pendencias_humano: 1
+pendencias_humano: 0
 ---
 
 # DEP-04 — GitHub Actions: deploy do front (build + S3 sync + invalidate, via OIDC)

--- a/docs/status/DEP-04.md
+++ b/docs/status/DEP-04.md
@@ -14,7 +14,7 @@ gates:
   branch_convencao: ok
   territorio: ok
 commits:
-  - null
+  - 1844507
 pr: null
 desvios: 0
 pendencias_humano: 1

--- a/docs/status/DEP-04.md
+++ b/docs/status/DEP-04.md
@@ -16,7 +16,7 @@ gates:
 commits:
   - 1844507
   - a466b9f
-pr: null
+pr: 67
 desvios: 0
 pendencias_humano: 0
 ---

--- a/docs/status/DEP-04.md
+++ b/docs/status/DEP-04.md
@@ -1,0 +1,87 @@
+---
+task: DEP-04
+titulo: "GitHub Actions: deploy do front (build + S3 sync + invalidate, via OIDC)"
+data: 2026-05-27
+branch: feature/dep-04-pipeline-deploy-front
+responsavel: claude-back
+estado: concluido
+gates:
+  build: na
+  lint: na
+  testes: na
+  testes_total: na
+  testes_novos: na
+  branch_convencao: ok
+  territorio: ok
+commits:
+  - null
+pr: null
+desvios: 0
+pendencias_humano: 1
+---
+
+# DEP-04 — GitHub Actions: deploy do front (build + S3 sync + invalidate, via OIDC)
+
+## O que foi feito
+
+**`financas_bot_telegram/infra/iam-github-oidc.tf` (novo):**
+- `aws_iam_openid_connect_provider.github` — provider OIDC singleton da conta para `token.actions.githubusercontent.com`, audience `sts.amazonaws.com`.
+- `aws_iam_role.gha_frontend_deploy` (`finbot-prod-gha-frontend-deploy`) — assume policy condicionada ao `sub` exato `repo:SSteringS/financas_bot_telegram:ref:refs/heads/main` e ao `aud` `sts.amazonaws.com`.
+- `aws_iam_policy.gha_frontend_deploy` — permissões mínimas: `s3:ListBucket` no bucket, `s3:GetObject/PutObject/DeleteObject` em `bucket/*`, `cloudfront:CreateInvalidation` na distribuição. Nada além.
+- Output `gha_frontend_deploy_role_arn` com o ARN da role.
+
+**`.github/workflows/deploy-frontend.yml` (novo):**
+- Dispara em push para `main` com mudança em `frontend/**`.
+- Autentica via OIDC (`aws-actions/configure-aws-credentials@v4`).
+- ARN hardcoded no workflow: `arn:aws:iam::776658251579:role/finbot-prod-gha-frontend-deploy` (conta 776658251579 já conhecida de DEP-02; nome da role é determinístico — criado pelo Terraform acima).
+- `npm ci` → `npm run build` → `aws s3 sync dist/ s3://finbot-frontend-prod-776658251579 --delete` → invalidação `E1WG4Q8MG3V9HY`.
+
+`terraform fmt -check`: limpo. `terraform validate`: Success.
+
+---
+
+## Desvios do plano
+
+Nenhum.
+
+---
+
+## Decisões tomadas durante a execução
+
+- **ARN da role hardcoded no workflow** em vez de referência via output/variável — isso é uma limitação técnica: workflows GitHub Actions não têm como consumir outputs do Terraform em tempo de escrita do YAML. O ARN é determinístico (conta 776658251579 + nome `finbot-prod-gha-frontend-deploy`) e já era conhecido.
+- **Slug `SSteringS/financas_bot_telegram`** obtido via `git remote get-url origin` — confirmado como `https://github.com/SSteringS/financas_bot_telegram.git`.
+
+---
+
+## Decisões pendentes (esperando humano)
+
+**1 — Provider OIDC é singleton da conta — confirmar/importar se já existir**
+
+O recurso `aws_iam_openid_connect_provider.github` pode conflitar se a conta já tiver um provider para `token.actions.githubusercontent.com` criado fora deste módulo Terraform. Nesse caso, importar em vez de criar:
+
+```bash
+terraform import aws_iam_openid_connect_provider.github \
+  arn:aws:iam::776658251579:oidc-provider/token.actions.githubusercontent.com
+```
+
+Checar antes do `terraform apply`:
+```bash
+aws iam list-open-id-connect-providers
+```
+
+Se não existir, o `apply` cria normalmente.
+
+---
+
+## Próximos passos / observações pro próximo
+
+- **`frontend/.env.production`** ainda tem `VITE_API_BASE_URL=https://api.finbot.dom.br` (domínio antigo). Deve virar `https://api.satyansaita.com` antes do primeiro build de prod valer (território do Claude do front).
+- Antes do primeiro disparo real do workflow: confirmar que o `terraform apply` do `iam-github-oidc.tf` foi aplicado e a role existe na conta.
+- O `deploy.yml` do back dispara em qualquer push para `main` sem filtro de path — um push de front vai redisparar o deploy do back à toa. Adicionar `paths` ao `deploy.yml` é um follow-up fora desta task.
+
+---
+
+## Arquivos criados/modificados
+
+- `financas_bot_telegram/infra/iam-github-oidc.tf` (novo: provider OIDC + role + policy mínima)
+- `.github/workflows/deploy-frontend.yml` (novo: pipeline de deploy do front)

--- a/financas_bot_telegram/infra/iam-github-oidc.tf
+++ b/financas_bot_telegram/infra/iam-github-oidc.tf
@@ -1,0 +1,87 @@
+# ---- OIDC provider: GitHub Actions → AWS (singleton da conta) ----
+# Se já existir um provider com esta URL, importar em vez de duplicar:
+#   terraform import aws_iam_openid_connect_provider.github \
+#     arn:aws:iam::<account_id>:oidc-provider/token.actions.githubusercontent.com
+resource "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+
+  client_id_list = ["sts.amazonaws.com"]
+
+  # Thumbprint da CA raiz do GitHub OIDC (estável; atualizar se a CA rodar)
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+# ---- Role assumível pelo workflow de deploy do front ----
+data "aws_iam_policy_document" "gha_frontend_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    # Escopo: só o branch main do repo — evita que qualquer fork/branch assuma a role
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:SSteringS/financas_bot_telegram:ref:refs/heads/main"]
+    }
+  }
+}
+
+resource "aws_iam_role" "gha_frontend_deploy" {
+  name               = "finbot-prod-gha-frontend-deploy"
+  assume_role_policy = data.aws_iam_policy_document.gha_frontend_assume.json
+}
+
+# ---- Policy mínima: S3 (bucket do front) + CloudFront (invalidação) ----
+data "aws_iam_policy_document" "gha_frontend_policy" {
+  statement {
+    sid       = "S3ListBucket"
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.frontend.arn]
+  }
+
+  statement {
+    sid    = "S3ReadWrite"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+    resources = ["${aws_s3_bucket.frontend.arn}/*"]
+  }
+
+  statement {
+    sid       = "CloudFrontInvalidate"
+    effect    = "Allow"
+    actions   = ["cloudfront:CreateInvalidation"]
+    resources = [aws_cloudfront_distribution.frontend.arn]
+  }
+}
+
+resource "aws_iam_policy" "gha_frontend_deploy" {
+  name   = "finbot-prod-gha-frontend-deploy-policy"
+  policy = data.aws_iam_policy_document.gha_frontend_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "gha_frontend_deploy" {
+  role       = aws_iam_role.gha_frontend_deploy.name
+  policy_arn = aws_iam_policy.gha_frontend_deploy.arn
+}
+
+# ---- Output: ARN da role (usado no workflow) ----
+output "gha_frontend_deploy_role_arn" {
+  description = "ARN da role IAM para o workflow deploy-frontend.yml"
+  value       = aws_iam_role.gha_frontend_deploy.arn
+}

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,1 +1,1 @@
-VITE_API_BASE_URL=https://api.finbot.dom.br
+VITE_API_BASE_URL=https://api.satyansaita.com


### PR DESCRIPTION
## Summary

- `infra/iam-github-oidc.tf`: provider OIDC do GitHub + role IAM `finbot-prod-gha-frontend-deploy` com policy mínima (S3 + CloudFront) e subject restrito a `repo:SSteringS/financas_bot_telegram:ref:refs/heads/main`
- `.github/workflows/deploy-frontend.yml`: pipeline de deploy do front — OIDC auth → `npm ci` → `npm run build` → `aws s3 sync --delete` → `cloudfront create-invalidation`
- `frontend/.env.production`: corrigido para `VITE_API_BASE_URL=https://api.satyansaita.com`

## Resultado da revisão (ADR 0005)

Ver `docs/avaliacoes/backend-dep-04-pipeline-deploy-front.md`

- `terraform apply` executado pelo humano (2026-05-27) — role IAM criada na conta ✅
- `frontend/.env.production` corrigido (commit `a466b9f`) ✅
- Pendência restante: teste end-to-end do pipeline (push em `frontend/**` na `main`)

## Test plan

- [ ] Merge em `develop` → PR `develop→main` → merge em `main`
- [ ] Push com mudança em `frontend/**` → workflow `deploy-frontend.yml` dispara
- [ ] Confirmar run verde: OIDC auth → build → S3 sync → CloudFront invalidation
- [ ] Front acessível em `https://satyansaita.com` com versão atualizada

🤖 Generated with [Claude Code](https://claude.com/claude-code)