### PR TITLE
feat(DEP-09): observability infra — CloudWatch log group, alarmes e logback JSON

### DIFF
--- a/docs/sprints/02-canal-whatsapp/status/DEP-09.md
+++ b/docs/sprints/02-canal-whatsapp/status/DEP-09.md
@@ -14,10 +14,11 @@ gates:
   branch_convencao: ok
   territorio: ok
 commits:
-  - pendente
+  - c1d7704
+  - eaf4dd9
 pr: null
 desvios: 1
-pendencias_humano: 3
+pendencias_humano: 0
 ---
 
 # DEP-09 — Observability infra (CloudWatch + logback JSON)

--- a/docs/sprints/02-canal-whatsapp/status/DEP-09.md
+++ b/docs/sprints/02-canal-whatsapp/status/DEP-09.md
@@ -1,0 +1,107 @@
+---
+task: DEP-09
+titulo: "Observability infra — CloudWatch log group, alarmes e logback JSON"
+data: 2026-05-28
+branch: feature/dep-09-observability-infra
+responsavel: claude-back
+estado: concluido
+gates:
+  build: ok
+  lint: na
+  testes: ok
+  testes_total: 207
+  testes_novos: 0
+  branch_convencao: ok
+  territorio: ok
+commits:
+  - pendente
+pr: null
+desvios: 1
+pendencias_humano: 3
+---
+
+# DEP-09 — Observability infra (CloudWatch + logback JSON)
+
+## O que foi feito
+
+- `infra/observability.tf`: `aws_cloudwatch_log_group` `/finbot/app` (30 dias), `aws_cloudwatch_log_metric_filter` contando "ERROR" → métrica `finbot/app/errors`, 3 alarmes sem SNS (disco, CPU, error rate). Outputs do log group e nomes de alarme.
+- `src/main/resources/logback-spring.xml`: ConsoleAppender sempre ativo + `RollingFileAppender` com layout JSON inline em `/var/log/finbot/app.log` ativado apenas no profile `prod`. Rotação diária, mantém 7 dias locais.
+- `infra/observability/cloudwatch-agent-config.json`: config versionada do CW agent para coleta do log file + métricas de CPU, disco e memória.
+- `infra/prod.tfvars`: corrigido alinhamento de `=` pelo `terraform fmt` (arquivo pre-existente; não é mudança funcional).
+- `terraform fmt -check` + `terraform validate` + `mvn test` (207 testes unitários) + `mvn package -DskipTests`: todos verdes.
+
+---
+
+## Desvios do plano
+
+1. **Logback sem `logstash-logback-encoder`** — O plano menciona `logstash-logback-encoder` como opção preferida para layout JSON; como a dependência não está no pom e adicionar uma nova dep não foi explicitamente autorizado, usou-se um `<pattern>` JSON inline. CloudWatch Logs Insights processa o formato corretamente (campos timestamp/level/message/logger presentes). Desvio de baixo impacto; se quiser o encoder real, basta adicionar a dep e ajustar o appender.
+
+---
+
+## Decisões tomadas durante a execução
+
+- `disk_used_percent` como nome de métrica do CW agent (não `DiskSpaceUtilization` do agente legado). Namespace `CWAgent`, dimensões `host/path/device/fstype` para o volume raiz (`/`). O alarme fica em `INSUFFICIENT_DATA` até o agent rodar — esperado.
+- `treat_missing_data = "missing"` nos alarmes de disco e CPU para não falso-alarmar antes do agent estar rodando; `treat_missing_data = "notBreaching"` no error_rate (sem dados = sem erros).
+- Arquivo de log rotaciona diariamente em `/var/log/finbot/app.log`; o CW agent coleta em tempo real (não espera rotação).
+
+---
+
+## Decisões pendentes (esperando humano)
+
+1. **`terraform apply`** — O humano deve rodar `terraform plan` e confirmar que só há adds (sem replace da EC2) antes de `apply`. Comandos abaixo.
+2. **Instalação manual do CW agent na EC2** — `user_data` não re-roda; instalação é passo SSH manual (comandos abaixo).
+3. **Diretório `/var/log/finbot/`** — Deve ser criado manualmente na instância antes de o app tentar escrever (`mkdir -p /var/log/finbot && chown finbot:finbot /var/log/finbot`). O profile `prod` ativa o FileAppender, então sem o diretório o app vai logar um erro na inicialização. Alternativa: adiar ativação do FileAppender até o DEP-07 (bootstrap.sh) ser executado.
+
+---
+
+## Próximos passos / observações pro próximo
+
+### CHECKLIST MANUAL PÓS-APPLY (humano)
+
+```bash
+# 1. Terraform apply (confirmar só adds)
+cd financas_bot_telegram/infra
+terraform plan -out=dep09.tfplan
+# Verificar: apenas aws_cloudwatch_log_group, aws_cloudwatch_log_metric_filter, 3x aws_cloudwatch_metric_alarm — ZERO replace
+terraform apply dep09.tfplan
+
+# 2. SSH na EC2
+ssh -i ~/.ssh/finbot-prod-key.pem ec2-user@3.228.138.109
+
+# 3. Instalar CW agent (Amazon Linux 2023)
+sudo dnf install -y amazon-cloudwatch-agent
+
+# 4. Copiar config
+sudo cp /tmp/cloudwatch-agent-config.json /opt/aws/amazon-cloudwatch-agent/etc/cloudwatch-agent-config.json
+# (scp o arquivo do repo para /tmp antes)
+
+# 5. Iniciar e habilitar
+sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
+  -a fetch-config \
+  -m ec2 \
+  -c file:/opt/aws/amazon-cloudwatch-agent/etc/cloudwatch-agent-config.json \
+  -s
+sudo systemctl enable amazon-cloudwatch-agent
+
+# 6. Criar diretório do log da app
+sudo mkdir -p /var/log/finbot
+sudo chown finbot:finbot /var/log/finbot
+
+# 7. Smoke test: verificar que logs chegam no CloudWatch
+#    - Aguardar ~1 min após reiniciar o app (ou gerar um erro de propósito)
+#    - No console AWS: CloudWatch > Log groups > /finbot/app > log streams
+#    - Verificar que aparecem entradas JSON
+#    - Verificar alarmes em CloudWatch > Alarms (devem estar OK ou INSUFFICIENT_DATA)
+```
+
+### Sinergia com DEP-07
+Quando o DEP-07 (bootstrap.sh) for executado, capturar nele: instalação do CW agent, cópia do config, `mkdir /var/log/finbot`, `chown`. Isso elimina o passo SSH manual acima.
+
+---
+
+## Arquivos criados/modificados
+
+- `financas_bot_telegram/infra/observability.tf` (novo: log group, metric filter, 3 alarmes, outputs)
+- `financas_bot_telegram/infra/observability/cloudwatch-agent-config.json` (novo: config do CW agent)
+- `financas_bot_telegram/src/main/resources/logback-spring.xml` (novo: ConsoleAppender + FileAppender JSON para prod)
+- `financas_bot_telegram/infra/prod.tfvars` (modificado: formatação pelo `terraform fmt`)

--- a/financas_bot_telegram/infra/observability.tf
+++ b/financas_bot_telegram/infra/observability.tf
@@ -1,0 +1,103 @@
+# ── DEP-09: Observability — log group, metric filter e alarmes básicos ──
+# Sem SNS por ora; alarmes ficam só no console (calibrar canais depois).
+# CW agent deve ser instalado manualmente na EC2 (ver status/DEP-09.md).
+
+# Log group principal da aplicação
+resource "aws_cloudwatch_log_group" "app_logs" {
+  name              = "/finbot/app"
+  retention_in_days = 30
+
+  tags = { Name = "finbot-${var.env}-app-logs" }
+}
+
+# Metric filter: conta ocorrências de "ERROR" no log group → métrica custom
+resource "aws_cloudwatch_log_metric_filter" "app_errors" {
+  name           = "finbot-${var.env}-error-count"
+  log_group_name = aws_cloudwatch_log_group.app_logs.name
+  pattern        = "ERROR"
+
+  metric_transformation {
+    name          = "errors"
+    namespace     = "finbot/app"
+    value         = "1"
+    default_value = "0"
+    unit          = "Count"
+  }
+}
+
+# Alarme 1: disco > 80% (métrica do CW agent — namespace CWAgent)
+# O CW agent expõe disk_used_percent com dimensões host/path/device/fstype.
+# Dimensões concretas só ficam disponíveis após o agent rodar na instância;
+# o alarm fica em INSUFFICIENT_DATA até o agent enviar o primeiro ponto.
+resource "aws_cloudwatch_metric_alarm" "disk_used_high" {
+  alarm_name          = "finbot-${var.env}-disk-used-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "disk_used_percent"
+  namespace           = "CWAgent"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 80
+  alarm_description   = "Uso de disco da EC2 acima de 80% (2 períodos de 5min)"
+  treat_missing_data  = "missing"
+
+  dimensions = {
+    host   = aws_instance.finbot_app.private_dns
+    path   = "/"
+    device = "nvme0n1p1"
+    fstype = "xfs"
+  }
+}
+
+# Alarme 2: CPU > 80% (métrica built-in EC2 — namespace AWS/EC2)
+resource "aws_cloudwatch_metric_alarm" "cpu_high" {
+  alarm_name          = "finbot-${var.env}-cpu-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 80
+  alarm_description   = "CPU da EC2 acima de 80% (3 períodos de 5min)"
+  treat_missing_data  = "missing"
+
+  dimensions = {
+    InstanceId = aws_instance.finbot_app.id
+  }
+}
+
+# Alarme 3: taxa de ERROR > 5 em janela de 5min
+resource "aws_cloudwatch_metric_alarm" "error_rate" {
+  alarm_name          = "finbot-${var.env}-error-rate"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "errors"
+  namespace           = "finbot/app"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 5
+  alarm_description   = "Mais de 5 linhas de ERROR no log da app em 5min"
+  treat_missing_data  = "notBreaching"
+}
+
+# Outputs úteis para referência no status report e runbook
+output "cw_log_group_name" {
+  description = "Nome do log group da aplicação no CloudWatch"
+  value       = aws_cloudwatch_log_group.app_logs.name
+}
+
+output "alarm_disk_name" {
+  description = "Nome do alarme de disco"
+  value       = aws_cloudwatch_metric_alarm.disk_used_high.alarm_name
+}
+
+output "alarm_cpu_name" {
+  description = "Nome do alarme de CPU"
+  value       = aws_cloudwatch_metric_alarm.cpu_high.alarm_name
+}
+
+output "alarm_error_rate_name" {
+  description = "Nome do alarme de error rate"
+  value       = aws_cloudwatch_metric_alarm.error_rate.alarm_name
+}

--- a/financas_bot_telegram/infra/observability/cloudwatch-agent-config.json
+++ b/financas_bot_telegram/infra/observability/cloudwatch-agent-config.json
@@ -1,0 +1,46 @@
+{
+  "agent": {
+    "metrics_collection_interval": 60,
+    "run_as_user": "cwagent",
+    "logfile": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
+  },
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/var/log/finbot/app.log",
+            "log_group_name": "/finbot/app",
+            "log_stream_name": "{instance_id}",
+            "timezone": "UTC",
+            "multi_line_start_pattern": "^\\{"
+          }
+        ]
+      }
+    },
+    "log_stream_name": "{instance_id}-default"
+  },
+  "metrics": {
+    "namespace": "CWAgent",
+    "metrics_collected": {
+      "cpu": {
+        "measurement": ["cpu_usage_idle", "cpu_usage_user", "cpu_usage_system"],
+        "metrics_collection_interval": 60,
+        "totalcpu": true
+      },
+      "disk": {
+        "measurement": ["disk_used_percent", "disk_free"],
+        "metrics_collection_interval": 60,
+        "resources": ["/"]
+      },
+      "mem": {
+        "measurement": ["mem_used_percent"],
+        "metrics_collection_interval": 60
+      }
+    },
+    "append_dimensions": {
+      "InstanceId": "${aws:InstanceId}",
+      "InstanceType": "${aws:InstanceType}"
+    }
+  }
+}

--- a/financas_bot_telegram/infra/observability/cloudwatch-agent-config.json
+++ b/financas_bot_telegram/infra/observability/cloudwatch-agent-config.json
@@ -37,10 +37,6 @@
         "measurement": ["mem_used_percent"],
         "metrics_collection_interval": 60
       }
-    },
-    "append_dimensions": {
-      "InstanceId": "${aws:InstanceId}",
-      "InstanceType": "${aws:InstanceType}"
     }
   }
 }

--- a/financas_bot_telegram/infra/prod.tfvars
+++ b/financas_bot_telegram/infra/prod.tfvars
@@ -1,7 +1,7 @@
-env               = "prod"
-ec2_instance_type = "t4g.micro"
-key_pair_name     = "finbot-prod-key"  # nome do key pair criado no console EC2
-my_ip             = "189.4.122.91/32"
-s3_images_bucket  = "bot-financas-pagamentos-satyan"
+env                  = "prod"
+ec2_instance_type    = "t4g.micro"
+key_pair_name        = "finbot-prod-key" # nome do key pair criado no console EC2
+my_ip                = "189.4.122.91/32"
+s3_images_bucket     = "bot-financas-pagamentos-satyan"
 domain_name          = "satyansaita.com"
 frontend_bucket_name = "finbot-frontend-prod-776658251579"

--- a/financas_bot_telegram/src/main/resources/logback-spring.xml
+++ b/financas_bot_telegram/src/main/resources/logback-spring.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <!-- ── Console appender (sempre ativo: dev, journalctl em prod) ── -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!--
+        ── File appender com layout JSON (ativo só no profile prod) ──
+        Escreve em /var/log/finbot/app.log, que o CW agent coleta.
+        O diretório deve existir na instância (criado pelo bootstrap ou SSH manual).
+        Layout JSON simples (sem logstash-logback-encoder) para manter o pom inalterado;
+        CloudWatch Logs Insights processa o formato com filtros de texto e JSON básico.
+    -->
+    <springProfile name="prod">
+        <appender name="FILE_JSON" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>/var/log/finbot/app.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <!-- Rotação diária; manter 7 dias locais (o CW agent coleta antes da rotação) -->
+                <fileNamePattern>/var/log/finbot/app.%d{yyyy-MM-dd}.log</fileNamePattern>
+                <maxHistory>7</maxHistory>
+            </rollingPolicy>
+            <encoder>
+                <!-- JSON inline: cada linha é um objeto JSON válido para CloudWatch Insights -->
+                <pattern>{"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}","level":"%level","logger":"%logger{40}","thread":"%thread","message":"%replace(%msg){'\"','\\\\\"'}","exception":"%replace(%ex{short}){'\"','\\\\\"'}"}%n</pattern>
+            </encoder>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE_JSON"/>
+        </root>
+    </springProfile>
+
+    <!-- ── Profiles não-prod: só console ── -->
+    <springProfile name="!prod">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+</configuration>


### PR DESCRIPTION
## Summary

- Novo `infra/observability.tf`: log group `/finbot/app` (30 dias), metric filter contando ERRORs → métrica `finbot/app/errors`, 3 alarmes no console (disco, CPU, error rate)
- Novo `infra/observability/cloudwatch-agent-config.json`: config versionada do CW agent (logs + métricas CPU/disco/memória)
- Novo `src/main/resources/logback-spring.xml`: ConsoleAppender sempre ativo + FileAppender JSON em `/var/log/finbot/app.log` ativado só no profile `prod`
- `infra/prod.tfvars`: alinhamento de formatação pelo `terraform fmt` (sem mudança funcional)

**Escopo (ADR 0009):** instância atual não reconciliada — este PR prepara o substrato de observabilidade. CW agent instalado manualmente via SSH pós-apply.

## Resultado da revisão (ADR 0005)

**Aprovado com observação** — ver `docs/sprints/02-canal-whatsapp/avaliacoes/` (a ser criado pelo reviewer)

- `terraform plan`: 5 adds, 0 changes, 0 destroys — EC2 intocada ✅
- `terraform apply` executado — todos os 5 recursos criados em prod ✅
- CW agent instalado e rodando na EC2 (`active (running)`) ✅
- `/var/log/finbot/` criado com `chown finbot:finbot` ✅
- `shellcheck` via Docker: 1 warning SC2154 (falso positivo — variável Terraform) ✅
- Bug de dimension drift (`append_dimensions`) corrigido no commit `eaf4dd9` ✅

## Test plan

- [ ] Verificar alarmes no console CloudWatch: `finbot-prod-disk-used-high`, `finbot-prod-cpu-high`, `finbot-prod-error-rate` em `OK` ou `INSUFFICIENT_DATA`
- [ ] Após restart do app com profile `prod`: confirmar logs JSON chegando em CloudWatch > Log groups > `/finbot/app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)