### PR TITLE
fix: padronizar RestClient Telegram via Builder (spec §5.3)

### DIFF
--- a/docs/sprints/02-canal-whatsapp/status/FIX-padronizar-restclient-builder.md
+++ b/docs/sprints/02-canal-whatsapp/status/FIX-padronizar-restclient-builder.md
@@ -1,0 +1,81 @@
+---
+task: FIX-padronizar-restclient-builder
+titulo: "Padronizar criação do RestClient Telegram via Builder (spec §5.3)"
+data: 2026-05-29
+branch: fix/padronizar-restclient-builder
+responsavel: claude-back
+estado: concluido
+gates:
+  build: ok
+  lint: na
+  testes: ok
+  testes_total: 248
+  testes_novos: 0
+  branch_convencao: ok
+  territorio: ok
+commits:
+  - cd48a59
+pr: null
+desvios: 0
+pendencias_humano: 0
+---
+
+# FIX — Padronizar criação do RestClient Telegram via Builder (spec §5.3)
+
+## O que foi feito
+
+Único arquivo modificado: `infra/AppConfig.java`.
+
+Antes:
+```java
+@Bean
+public RestClient restClient() {
+    return RestClient.create();
+}
+```
+
+Depois:
+```java
+// Singleton construído a partir do RestClient.Builder auto-configurado — mantém compatibilidade
+// com @RestClientTest; padrão da spec §5.3 (docs/architecture/adapter-whatsapp-cloud-api.md).
+@Bean
+public RestClient restClient(RestClient.Builder builder) {
+    return builder.build();
+}
+```
+
+O `RestClient.Builder` é auto-configurado pelo Spring Boot (`RestClientAutoConfiguration`). Como os services Telegram (`TelegramMessageSenderService`, `TelegramFileDownloaderService`) montam URLs absolutas manualmente, nenhuma base URL é necessária no bean — `builder.build()` é suficiente.
+
+## Testes Telegram a migrar
+
+Confirmado: **não há testes** para `TelegramMessageSenderService` nem `TelegramFileDownloaderService`. Nenhuma migração necessária.
+
+---
+
+## Desvios do plano
+
+Nenhum.
+
+---
+
+## Decisões tomadas durante a execução
+
+Nenhuma decisão não-óbvia. Mudança mecânica conforme a spec.
+
+---
+
+## Decisões pendentes (esperando humano)
+
+Nenhuma — tarefa fechada.
+
+---
+
+## Próximos passos / observações pro próximo
+
+Os dois services Telegram não têm testes. Quando houver necessidade de testar o comportamento HTTP do Telegram sender/downloader, o padrão agora viabiliza `@RestClientTest` + `MockRestServiceServer` (mesma abordagem do BE-18).
+
+---
+
+## Arquivos criados/modificados
+
+- `infra/AppConfig.java` (modificado: `restClient()` via Builder + comentário de convenção)

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/infra/AppConfig.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/infra/AppConfig.java
@@ -8,9 +8,11 @@ import org.springframework.web.client.RestClient;
 @Configuration
 public class AppConfig {
 
+  // Singleton construído a partir do RestClient.Builder auto-configurado — mantém compatibilidade
+  // com @RestClientTest; padrão da spec §5.3 (docs/architecture/adapter-whatsapp-cloud-api.md).
   @Bean
-  public RestClient restClient() {
-    return RestClient.create();
+  public RestClient restClient(RestClient.Builder builder) {
+    return builder.build();
   }
 
   @Bean


### PR DESCRIPTION
## Resumo

- Alinha `AppConfig.restClient()` com o padrão da spec §5.3: singleton construído a partir do `RestClient.Builder` auto-configurado pelo Spring Boot, em vez de `RestClient.create()` direto.
- Viabiliza `@RestClientTest` + `MockRestServiceServer` para os adapters Telegram quando houver necessidade de teste — a slice amarra o mock ao Builder, e como o singleton vem dele, o mock vale pro singleton inteiro.
- Fecha o item de `PENDENCIAS-TECNICAS.md` "Padronizar criação do RestClient via Builder".

## Gates

- build: ok · lint: na · testes: 248 passando (0 novos — mudança puramente estrutural)
- branch_convencao: ok · território: apenas `financas_bot_telegram/infra/AppConfig.java` + `docs/`

## Test plan

- [ ] Verificar que a aplicação sobe normalmente em prod após o deploy (comportamento do `RestClient` é idêntico — só muda a origem da instância)

🤖 Generated with [Claude Code](https://claude.com/claude-code)