### PR TITLE
feat(BE-17b): renomear rota Telegram /webhook → /webhook/telegram

### DIFF
--- a/docs/sprints/02-canal-whatsapp/status/BE-17b.md
+++ b/docs/sprints/02-canal-whatsapp/status/BE-17b.md
@@ -1,0 +1,102 @@
+---
+task: BE-17b
+titulo: "Renomear rota Telegram /webhook → /webhook/telegram"
+data: 2026-05-30
+branch: feature/be-17b-renomear-rota-telegram
+responsavel: claude-back
+estado: concluido
+gates:
+  build: ok
+  lint: na
+  testes: ok
+  testes_total: 222
+  testes_novos: 0
+  branch_convencao: ok
+  territorio: ok
+commits:
+  - ac9ced6
+pr: null
+desvios: 0
+pendencias_humano: 0
+---
+
+# BE-17b — Renomear rota Telegram `/webhook` → `/webhook/telegram`
+
+## O que foi feito
+
+Uma linha mudada no controller + um teste atualizado:
+
+- **`TelegramWebhookController`**: `@PostMapping("/webhook")` → `@PostMapping("/webhook/telegram")`.
+- **`JwtAuthenticationFilterTest`**: método `naoDeveAplicarFiltroEmWebhook` renomeado pra `naoDeveAplicarFiltroEmWebhookTelegram` e URI atualizada pra `/webhook/telegram`.
+
+Nenhum outro arquivo tocado — `grep -rn '"/webhook"' src/test` confirmou que só o teste do filtro referenciava o path antigo.
+
+---
+
+## Desvios do plano
+
+Nenhum.
+
+---
+
+## Decisões tomadas durante a execução
+
+- O `JwtAuthenticationFilter.shouldNotFilter` usa lógica genérica (`!path.startsWith("/api/v1/")`), não lista `/webhook` explicitamente. O teste apenas usava `/webhook` como exemplo representativo — atualizar o URI mantém o teste semanticamente correto.
+
+---
+
+## Decisões pendentes (esperando humano)
+
+Nenhuma — tarefa fechada.
+
+---
+
+## ⚠️ Passo operacional obrigatório pós-deploy
+
+**Esta mudança exige `setWebhook` imediatamente após o deploy.** Entre o deploy do código e a chamada abaixo, o Telegram entrega na rota antiga e recebe 404.
+
+### Janela (~5 min)
+
+```bash
+# 1. Confirmar que a rota nova está montada (espera 400/415 — existe mas sem payload)
+curl -X POST https://satyansaita.com/webhook/telegram -d 'x' -i
+
+# 2. Atualizar o webhook no Telegram
+curl -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/setWebhook" \
+  -d "url=https://satyansaita.com/webhook/telegram"
+
+# 3. Confirmar
+curl "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getWebhookInfo"
+```
+
+Resultado esperado em `getWebhookInfo`:
+- `"url": "https://satyansaita.com/webhook/telegram"`
+- `last_error_message` vazio ou ausente
+- `pending_update_count` zerado (pode demorar alguns segundos)
+
+```bash
+# 4. Smoke: mandar mensagem de teste pro bot via app do Telegram e confirmar resposta.
+```
+
+### Rollback (se algo der errado)
+
+```bash
+# Reverter o setWebhook pra URL antiga:
+curl -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/setWebhook" \
+  -d "url=https://satyansaita.com/webhook"
+# + revert do commit + redeploy restaura /webhook na app.
+```
+
+---
+
+## Próximos passos / observações pro próximo
+
+- Após confirmar `setWebhook` ok, atualizar `docs/STATE.md` anotando "rota Telegram agora `/webhook/telegram`".
+- Próxima task lógica: **BE-20** (deploy WhatsApp em prod + Meta config).
+
+---
+
+## Arquivos criados/modificados
+
+- `adapters/in/telegram/controller/TelegramWebhookController.java` (modificado: path `/webhook/telegram`)
+- `test/.../infra/security/JwtAuthenticationFilterTest.java` (modificado: URI do teste atualizada)

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/telegram/controller/TelegramWebhookController.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/telegram/controller/TelegramWebhookController.java
@@ -33,7 +33,7 @@ public class TelegramWebhookController {
     this.allowedUserIds = allowedUserIds;
   }
 
-  @PostMapping("/webhook")
+  @PostMapping("/webhook/telegram")
   public ResponseEntity<Void> receberMensagem(@RequestBody Update update, HttpServletRequest request) {
     logger.info("Recebendo mensagem do Telegram: {}", update);
     request.setAttribute("__update", update);

--- a/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/infra/security/JwtAuthenticationFilterTest.java
+++ b/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/infra/security/JwtAuthenticationFilterTest.java
@@ -93,9 +93,9 @@ class JwtAuthenticationFilterTest {
     }
 
     @Test
-    void naoDeveAplicarFiltroEmWebhook() throws Exception {
+    void naoDeveAplicarFiltroEmWebhookTelegram() throws Exception {
         MockHttpServletRequest req = new MockHttpServletRequest();
-        req.setRequestURI("/webhook");
+        req.setRequestURI("/webhook/telegram");
 
         assertThat(filter.shouldNotFilter(req)).isTrue();
     }


### PR DESCRIPTION
## Resumo

- `TelegramWebhookController`: `@PostMapping("/webhook")` → `@PostMapping("/webhook/telegram")` — simetria com `POST /webhook/whatsapp` (BE-19).
- `JwtAuthenticationFilterTest`: URI e nome do método atualizados para `/webhook/telegram`. O filtro JWT usa `!path.startsWith("/api/v1/")` sem listar `/webhook` explicitamente — nenhuma mudança no filtro necessária.

## Gates

- build: ok · lint: na · testes: 222 passando (0 novos)
- branch_convencao: ok · território: apenas `financas_bot_telegram/` + `docs/`

## ⚠️ Passo operacional obrigatório pós-deploy

Após o deploy, executar `setWebhook` imediatamente (janela de ~5 min onde Telegram entrega na rota antiga):

```bash
curl -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/setWebhook" \
  -d "url=https://satyansaita.com/webhook/telegram"
```

Ver runbook completo (incluindo rollback) no status report `docs/sprints/02-canal-whatsapp/status/BE-17b.md`.

## Test plan

- [ ] Após deploy + `setWebhook`: enviar mensagem de teste ao bot via Telegram e confirmar resposta normal
- [ ] `getWebhookInfo` mostra `"url": ".../webhook/telegram"` sem `last_error_message`

🤖 Generated with [Claude Code](https://claude.com/claude-code)