### PR TITLE
feat(QA-003): fixtures banco + auth + global-setup + payloads-telegra…

### DIFF
--- a/docs/sprints/03-folha-pagamento/status/QA-003-fixtures-banco-auth-payloads.md
+++ b/docs/sprints/03-folha-pagamento/status/QA-003-fixtures-banco-auth-payloads.md
@@ -1,0 +1,138 @@
+---
+task: QA-003
+titulo: "Fixtures — banco, auth, global-setup, payloads-telegram"
+data: 2026-06-03
+branch: feature/qa-003-fixtures-banco-auth-payloads
+responsavel: claude-front
+estado: concluido
+gates:
+  build: ok
+  lint: ok
+  testes: ok
+  testes_total: 61
+  testes_novos: 0
+  cobertura_pct: na
+  branch_convencao: ok
+  territorio: ok
+commits:
+  - e4ed7e5
+pr: null
+desvios: 2
+pendencias_humano: 0
+---
+
+# QA-003 — Fixtures (banco, auth, global-setup, payloads-telegram)
+
+---
+
+## O que foi feito
+
+Quatro arquivos criados em `frontend/e2e/fixtures/`:
+
+**`banco.ts`**
+- Conexão singleton via `mysql2/promise`, credenciais de `.env.e2e`, erro explícito se vars ausentes.
+- `garantirRequisitanteE2E()` — `INSERT IGNORE` do requisitante 99 (idempotente).
+- `limparDadosE2E()` — DELETE em cascata de comprovantes → pedidos_pagamento → auth_token, sempre com filtro `requisitante_id = 99`. **Nunca toca `requisitante_id != 99`.**
+- `semearPedidos(pedidos[])` — INSERT em `pedidos_pagamento` + comprovante se `sKeyComprovante` fornecido.
+- `querySql<T>(sql, params?)` — query genérica para asserções.
+- `fecharConexao()` — fecha a conexão (chamado em global-setup após init).
+
+**`auth.ts`**
+- `loginE2E(page)` — fluxo completo: POST `/admin/api/v1/requisitantes/99/convite` (header `X-Admin-Key`), extração do token via `new URL(url).searchParams.get('t')`, POST `/api/v1/auth/exchange`, parse do `Set-Cookie`, injeção de `finbot_session` via `page.context().addCookies()`.
+- Erros explícitos em cada passo: vars ausentes, API retornou não-2xx, cookie ausente.
+
+**`global-setup.ts`** (substitui o stub de QA-001)
+- Valida existência física de `.env.e2e` via `fs.existsSync` antes de tudo.
+- Lança `Error` claro com instrução `"Copie .env.e2e.example e preencha"` se ausente.
+- Chama `garantirRequisitanteE2E()` e fecha a conexão ao final.
+
+**`payloads-telegram.ts`**
+- `telegramUpdateTextoPuro({ fromUserId, text })` — Update com `message.text`. `update_id` único por chamada (counter baseado em `Date.now()`).
+- `telegramUpdateSticker({ fromUserId })` — Update com `message.sticker` (file_id sintético).
+- TODO preservado: `// TODO Fase 1.1: adicionar telegramUpdateFotoLegenda após decisão de mock (ADR 00XX)`
+- Exporta exatamente 2 factories no MVP.
+
+**Removido:** `frontend/e2e/fixtures/.gitkeep` (placeholder de QA-001 — substituído pelos arquivos reais).
+
+---
+
+## Validações realizadas
+
+| Validação | Resultado |
+|---|---|
+| `npm test` (Vitest) 61/61 | ✓ zero regressão |
+| `npm run lint` | ✓ limpo |
+| `npm run build` | ✓ exit 0 |
+| `telegramUpdateTextoPuro` campos corretos | ✓ `update_id` number, `from.id=99`, `text` correto |
+| `telegramUpdateSticker` campos corretos | ✓ `sticker.type='regular'`, `update_id` distinto do texto |
+| `update_ids` únicos entre chamadas | ✓ counter incremental |
+| Erro explícito com `.env.e2e` ausente | ✓ "Variáveis de banco ausentes. Verifique .env.e2e..." |
+| `global-setup.ts` falha ruidosamente sem `.env.e2e` | ✓ (`.env.e2e` não existe no ambiente de CI desta sessão) |
+
+**Validações que requerem `.env.e2e` preenchido** (não disponível nesta sessão):
+- `garantirRequisitanteE2E()` idempotência (2x) — **não executado**, requer credenciais MySQL
+- `limparDadosE2E()` preservação de Pedro (id=1) — **não executado**
+- `loginE2E(page)` injeta cookie corretamente — **não executado**, requer backend rodando
+
+Essas validações serão confirmadas no smoke do QA-004 (ciclo e2e:full completo).
+
+---
+
+## Desvios do plano
+
+**Desvio 1 (técnico, não de produto):** `mensagem_processada` **não é limpa** em `limparDadosE2E()`. A spec do arquiteto (§7.2) mostrava `DELETE FROM mensagem_processada WHERE telegram_user_id = '99'`, mas a tabela V4 real não tem coluna `telegram_user_id` — tem `canal` e `id_externo` (o `update_id`). Como cada test run usa `update_id` únicos (counter em `payloads-telegram.ts`), não há colisão entre runs e a limpeza não é necessária. Se no futuro `mensagem_processada` precisar ser limpa, usar `DELETE WHERE canal='TELEGRAM' AND id_externo IN (select ids gerados no run)`.
+
+**Desvio 2 (correção de infra, não de produto):** `e2e/tsconfig.json` corrigido — `allowImportingTsExtensions: false → true`. QA-001 setou explicitamente `false`, mas `global-setup.ts` (e `subir-stack.ts` de QA-002) usa extensão `.ts` no import path (padrão ESM/tsx necessário para runtime). Com `noEmit: true` já presente, `allowImportingTsExtensions: true` é válido e a correção elimina o erro `TS5097` que impedia o `tsc --noEmit` de passar nos arquivos e2e.
+
+---
+
+## Decisões tomadas durante a execução
+
+**Schema verificado contra as migrations:** todos os campos do INSERT em `banco.ts` foram conferidos contra V1–V6. `requisitante` tem coluna `canal_preferido` (adicionada na V5) — incluída no INSERT com valor `'TELEGRAM'`. `pedidos_pagamento` tem `data_pedido DATE NOT NULL` (V2) — incluída no INSERT.
+
+**`fecharConexao()` no global-setup:** após `garantirRequisitanteE2E()`, a conexão é fechada para liberar o socket. Cada test worker (Playwright) que precisar de banco abrirá sua própria conexão via `getConn()`. Evita keepalive desnecessário.
+
+**dotenv carregado com path absoluto:** `banco.ts` e `auth.ts` calculam o path de `.env.e2e` usando `__dirname` + `resolve('../..')`. Isso funciona independentemente do cwd de onde o script é chamado — desde que estejam em `e2e/fixtures/`.
+
+**`_smoke-banco.ts` não commitado:** criei um arquivo de smoke temporário para validação manual, mas o removi antes do commit — não é parte do escopo de QA-003.
+
+---
+
+## Decisões pendentes (esperando humano)
+
+Nenhuma — tarefa fechada.
+
+---
+
+## Próximos passos / observações pro próximo (QA-004)
+
+- **Criar `.env.e2e`** a partir de `.env.e2e.example` antes de rodar os specs.
+- `loginE2E(page)` depende do backend rodando (`E2E_BACKEND_URL=http://localhost:8080`) e do requisitante 99 existir no banco (garantido pelo `global-setup.ts`).
+- `semearPedidos` insere com `data_pedido` obrigatório — usar `'YYYY-MM-DD'` no campo `dataPedido`.
+- A propriedade `sKeyComprovante` é o `imagem_url` do comprovante (S3 key ou URL). Passar só para `status: 'PAGO'`.
+- O campo `e2e_full` no frontmatter não é obrigatório ainda (per §9.2 do desenho-testes — fica para quando QA-004 e a infra completa estiverem em develop).
+
+---
+
+## Padrões e decisões técnicas
+
+Esta task é infraestrutura de teste (QA), não feature React. Os padrões relevantes são de TypeScript/Node.js:
+
+**Singleton pattern** — `banco.ts` usa uma variável module-level `_conn: Connection | null` com `getConn()` como acesso controlado. Problema resolvido: evitar abrir N conexões MySQL em paralelo quando múltiplos helpers chamam `banco.ts` no mesmo worker. Trade-off: é um singleton com estado global no módulo — ok para scripts de teste, mas evitar em código de produção.
+
+**Fail-fast / Guard clauses** — `auth.ts` e `global-setup.ts` validam precondições no início (`!ADMIN_SECRET`, `!existsSync(envFile)`) e lançam `Error` com mensagem acionável antes de fazer qualquer I/O. Problema resolvido: falhas silenciosas (variável de ambiente não definida → fetch resulta em erro HTTP obscuro). Princípio aplicado: "fail loudly, fail early".
+
+**Factory functions** — `payloads-telegram.ts` expõe `telegramUpdateTextoPuro` e `telegramUpdateSticker` como funções puras que retornam objetos tipados. Alternativa descartada: classes com `new TelegramUpdateBuilder()` seria over-engineering para objetos simples. Trade-off consciente: factories com `nextUpdateId()` têm side-effect (contador), mas a alternativa (passar `update_id` como parâmetro) adicionaria ruído desnecessário na maioria dos casos de uso.
+
+**Separação de responsabilidades** — cada arquivo tem uma única responsabilidade: `banco.ts` = I/O MySQL, `auth.ts` = fluxo de autenticação, `global-setup.ts` = orquestração de bootstrap, `payloads-telegram.ts` = construção de dados sintéticos. `global-setup.ts` não contém SQL; `banco.ts` não contém lógica de auth. DIP aplicado: `global-setup.ts` depende da abstração exportada por `banco.ts`, não dos detalhes da conexão.
+
+---
+
+## Arquivos criados/modificados
+
+- `frontend/e2e/fixtures/banco.ts` (novo: helpers DB com mysql2/promise)
+- `frontend/e2e/fixtures/auth.ts` (novo: loginE2E via magic link)
+- `frontend/e2e/fixtures/global-setup.ts` (modificado: substitui stub de QA-001)
+- `frontend/e2e/fixtures/payloads-telegram.ts` (novo: 2 factories de Update)
+- `frontend/e2e/fixtures/.gitkeep` (removido: placeholder de QA-001)
+- `frontend/e2e/tsconfig.json` (modificado: `allowImportingTsExtensions: false → true`, corrige TS5097)

--- a/frontend/e2e/fixtures/auth.ts
+++ b/frontend/e2e/fixtures/auth.ts
@@ -1,0 +1,100 @@
+/**
+ * auth.ts — helper de autenticação para a suíte E2E.
+ *
+ * loginE2E(page) executa o fluxo de magic link completo:
+ *   1. Gera convite via admin API
+ *   2. Extrai token da URL retornada
+ *   3. Faz exchange via /api/v1/auth/exchange
+ *   4. Injeta cookie finbot_session no contexto do Playwright
+ */
+
+import type { Page } from '@playwright/test';
+import { config as loadEnv } from 'dotenv';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+loadEnv({ path: resolve(__dirname, '..', '..', '.env.e2e') });
+
+const BACKEND = process.env['E2E_BACKEND_URL'] ?? 'http://localhost:8080';
+const ADMIN_SECRET = process.env['E2E_ADMIN_SECRET'];
+
+/**
+ * Autentica o requisitante de teste (id=99) no Playwright.
+ * Injeta cookie finbot_session no contexto da page.
+ *
+ * Pré-condição: requisitante 99 deve existir no banco (garantirRequisitanteE2E no globalSetup).
+ */
+export async function loginE2E(page: Page): Promise<void> {
+  if (!ADMIN_SECRET) {
+    throw new Error(
+      'E2E_ADMIN_SECRET não definido. Verifique .env.e2e (copie de .env.e2e.example).',
+    );
+  }
+
+  // 1. Gerar convite via admin API
+  const conviteRes = await fetch(
+    `${BACKEND}/admin/api/v1/requisitantes/99/convite`,
+    {
+      method: 'POST',
+      headers: { 'X-Admin-Key': ADMIN_SECRET },
+    },
+  );
+
+  if (!conviteRes.ok) {
+    throw new Error(
+      `Admin API retornou ${conviteRes.status}. ` +
+        `Verifique E2E_ADMIN_SECRET e que o backend está rodando em ${BACKEND}.`,
+    );
+  }
+
+  const { url } = (await conviteRes.json()) as { url: string };
+
+  // 2. Extrair token do query param ?t=
+  const token = new URL(url).searchParams.get('t');
+  if (!token) {
+    throw new Error(`Token não encontrado na URL de convite: ${url}`);
+  }
+
+  // 3. Exchange token → cookie finbot_session
+  const exchangeRes = await fetch(`${BACKEND}/api/v1/auth/exchange`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ token }),
+  });
+
+  if (!exchangeRes.ok) {
+    throw new Error(`Exchange falhou com status ${exchangeRes.status}`);
+  }
+
+  // 4. Extrair valor do cookie do header Set-Cookie
+  const setCookie = exchangeRes.headers.get('set-cookie');
+  if (!setCookie) {
+    throw new Error('Exchange não retornou Set-Cookie header');
+  }
+
+  const cookieValue = parseCookieValue(setCookie, 'finbot_session');
+
+  // 5. Injetar cookie no contexto do Playwright
+  await page.context().addCookies([
+    {
+      name: 'finbot_session',
+      value: cookieValue,
+      domain: 'localhost',
+      path: '/',
+      httpOnly: true,
+      sameSite: 'Lax',
+    },
+  ]);
+}
+
+// ── Helpers internos ──────────────────────────────────────────────────────────
+
+function parseCookieValue(setCookie: string, name: string): string {
+  // Set-Cookie: finbot_session=<valor>; Path=/; HttpOnly; SameSite=Lax; Max-Age=...
+  const match = setCookie.match(new RegExp(`${name}=([^;]+)`));
+  if (!match?.[1]) {
+    throw new Error(`Cookie '${name}' não encontrado em Set-Cookie: ${setCookie}`);
+  }
+  return match[1];
+}

--- a/frontend/e2e/fixtures/banco.ts
+++ b/frontend/e2e/fixtures/banco.ts
@@ -1,0 +1,151 @@
+/**
+ * banco.ts — helpers de banco para a suíte E2E.
+ *
+ * Usa mysql2/promise com as credenciais de .env.e2e.
+ * Requisitante de teste: id=99 ("E2E Test User").
+ * NUNCA toca em dados com requisitante_id != 99.
+ */
+
+import { createConnection, Connection } from 'mysql2/promise';
+import { config as loadEnv } from 'dotenv';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+loadEnv({ path: resolve(__dirname, '..', '..', '.env.e2e') });
+
+// ── Tipos públicos ────────────────────────────────────────────────────────────
+
+export interface PedidoFixture {
+  descricao: string;
+  valor: number;
+  status: 'PENDENTE' | 'PAGO';
+  tipo: 'BOLETO' | 'PIX' | 'TED' | 'AGENDAMENTO' | 'OUTRO';
+  dataPedido: string; // YYYY-MM-DD
+  sKeyComprovante?: string; // opcional — imagem_url do comprovante, só para PAGO
+}
+
+// ── Conexão singleton ────────────────────────────────────────────────────────
+
+let _conn: Connection | null = null;
+
+async function getConn(): Promise<Connection> {
+  if (_conn) return _conn;
+
+  const host = process.env['E2E_DB_HOST'];
+  const port = process.env['E2E_DB_PORT'];
+  const user = process.env['E2E_DB_USER'];
+  const password = process.env['E2E_DB_PASSWORD'];
+  const database = process.env['E2E_DB_NAME'];
+
+  if (!host || !user || !password || !database) {
+    throw new Error(
+      'Variáveis de banco ausentes. Verifique .env.e2e (copie de .env.e2e.example).\n' +
+        `  E2E_DB_HOST=${host ?? '(ausente)'}\n` +
+        `  E2E_DB_USER=${user ?? '(ausente)'}\n` +
+        `  E2E_DB_NAME=${database ?? '(ausente)'}`,
+    );
+  }
+
+  _conn = await createConnection({
+    host,
+    port: Number(port ?? 3306),
+    user,
+    password,
+    database,
+  });
+  return _conn;
+}
+
+/** Fecha a conexão (chamar em globalTeardown quando implementado). */
+export async function fecharConexao(): Promise<void> {
+  if (_conn) {
+    await _conn.end();
+    _conn = null;
+  }
+}
+
+// ── Funções públicas ──────────────────────────────────────────────────────────
+
+/**
+ * Garante que o requisitante de teste (id=99) exista.
+ * Idempotente: rodar N vezes não duplica nem falha.
+ */
+export async function garantirRequisitanteE2E(): Promise<void> {
+  const c = await getConn();
+  await c.query(
+    `INSERT IGNORE INTO requisitante
+       (id, nome, telefone, email, ativo, criado_em, canal_preferido)
+     VALUES (99, 'E2E Test User', '+5511000000099', 'e2e@test.local', TRUE, NOW(), 'TELEGRAM')`,
+  );
+}
+
+/**
+ * Limpa APENAS os dados do requisitante de teste (id=99).
+ *
+ * ⚠️  SEGURANÇA: nenhum DELETE aqui toca registros com requisitante_id != 99.
+ *     Dados do Pedro (id=1) ficam intocados.
+ *
+ * Ordem de deleção respeita FK constraints:
+ *   comprovantes → pedidos_pagamento → auth_token
+ * mensagem_processada: NÃO limpa — usa update_id único por run (sem risco de colisão).
+ */
+export async function limparDadosE2E(): Promise<void> {
+  const c = await getConn();
+
+  // 1. Comprovantes dos pedidos do requisitante 99
+  await c.query(
+    `DELETE FROM comprovantes
+      WHERE pedido_id IN (
+        SELECT id FROM pedidos_pagamento WHERE requisitante_id = 99
+      )`,
+  );
+
+  // 2. Pedidos do requisitante 99
+  await c.query(
+    `DELETE FROM pedidos_pagamento WHERE requisitante_id = 99`,
+  );
+
+  // 3. Tokens de autenticação do requisitante 99
+  await c.query(
+    `DELETE FROM auth_token WHERE requisitante_id = 99`,
+  );
+}
+
+/**
+ * Insere pedidos de teste vinculados ao requisitante 99.
+ * Os IDs gerados são auto-incremento — use querySql para recuperá-los.
+ */
+export async function semearPedidos(pedidos: PedidoFixture[]): Promise<void> {
+  const c = await getConn();
+
+  for (const p of pedidos) {
+    const [result] = await c.query<import('mysql2').ResultSetHeader>(
+      `INSERT INTO pedidos_pagamento
+         (requisitante_id, descricao, valor, status, tipo, data_pedido, data_criacao)
+       VALUES (99, ?, ?, ?, ?, ?, NOW())`,
+      [p.descricao, p.valor, p.status, p.tipo, p.dataPedido],
+    );
+
+    if (p.sKeyComprovante && p.status === 'PAGO') {
+      await c.query(
+        `INSERT INTO comprovantes (pedido_id, imagem_url, data_pagamento)
+         VALUES (?, ?, NOW())`,
+        [result.insertId, p.sKeyComprovante],
+      );
+    }
+  }
+}
+
+/**
+ * Query genérica para asserções nos testes.
+ * Ex.: await querySql('SELECT valor FROM pedidos_pagamento WHERE requisitante_id = 99')
+ */
+export async function querySql<T = Record<string, unknown>>(
+  sql: string,
+  params: unknown[] = [],
+): Promise<T[]> {
+  const c = await getConn();
+  const [rows] = await c.query(sql, params);
+  return rows as T[];
+}

--- a/frontend/e2e/fixtures/global-setup.ts
+++ b/frontend/e2e/fixtures/global-setup.ts
@@ -1,8 +1,37 @@
 /**
- * Global setup stub — será substituído em QA-003 (fixtures banco + auth).
- * Criado em QA-001 apenas para que `playwright.config.ts` possa ser carregado
- * sem erro de módulo durante `--list` e verificações de config.
+ * global-setup.ts — inicialização global da suíte E2E.
+ *
+ * Chamado 1x pelo Playwright antes de qualquer teste (playwright.config.ts → globalSetup).
+ * Garante que o requisitante de teste (id=99) existe no banco.
+ *
+ * Falha ruidosamente se .env.e2e não estiver configurado.
  */
+
+import { existsSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { config as loadEnv } from 'dotenv';
+import { garantirRequisitanteE2E, fecharConexao } from './banco.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const envFile = resolve(__dirname, '..', '..', '.env.e2e');
+
 export default async function globalSetup(): Promise<void> {
-  // QA-003 implementará: await garantirRequisitanteE2E()
+  // Validação explícita: .env.e2e deve existir
+  if (!existsSync(envFile)) {
+    throw new Error(
+      'Arquivo .env.e2e não encontrado. Copie .env.e2e.example e preencha.\n' +
+        `  Esperado em: ${envFile}`,
+    );
+  }
+
+  // Carregar vars (pode já estar carregado pelo playwright.config.ts — idempotente)
+  loadEnv({ path: envFile });
+
+  console.log('[global-setup] Garantindo requisitante E2E (id=99)...');
+  await garantirRequisitanteE2E();
+  console.log('[global-setup] ✓ Requisitante E2E pronto');
+
+  // Fechar conexão após setup — cada test worker abre a sua
+  await fecharConexao();
 }

--- a/frontend/e2e/fixtures/payloads-telegram.ts
+++ b/frontend/e2e/fixtures/payloads-telegram.ts
@@ -1,0 +1,141 @@
+/**
+ * payloads-telegram.ts — factories de Updates sintéticos do Telegram Bot API.
+ *
+ * Produz objetos compatíveis com https://core.telegram.org/bots/api#update
+ * para uso nos testes E2E de webhook.
+ *
+ * MVP — 2 factories exportadas:
+ *   - telegramUpdateTextoPuro  (message.text)
+ *   - telegramUpdateSticker    (message.sticker)
+ *
+ * TODO Fase 1.1: adicionar telegramUpdateFotoLegenda após decisão de mock (ADR 00XX)
+ *   Bloqueado por: decisão sobre como o back trata download de mídia em E2E
+ *   (§3 da spec qa-suite-e2e-fase1.md — opções: WireMock, flag skip-media, stub @Profile)
+ */
+
+// ── Contador de update_id (único por execução) ────────────────────────────────
+
+let _updateCounter = Date.now();
+
+function nextUpdateId(): number {
+  return _updateCounter++;
+}
+
+function nextMessageId(): number {
+  return Math.floor(Math.random() * 900_000) + 100_000;
+}
+
+function nowUnix(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+// ── Tipos Telegram (mínimo necessário) ───────────────────────────────────────
+
+interface TelegramUser {
+  id: number;
+  is_bot: boolean;
+  first_name: string;
+}
+
+interface TelegramChat {
+  id: number;
+  type: 'private' | 'group' | 'supergroup' | 'channel';
+}
+
+interface TelegramMessage {
+  message_id: number;
+  from: TelegramUser;
+  chat: TelegramChat;
+  date: number;
+  text?: string;
+  caption?: string;
+  sticker?: TelegramSticker;
+  photo?: TelegramPhotoSize[];
+}
+
+interface TelegramSticker {
+  file_id: string;
+  file_unique_id: string;
+  type: 'regular' | 'mask' | 'custom_emoji';
+  width: number;
+  height: number;
+  is_animated: boolean;
+  is_video: boolean;
+}
+
+interface TelegramPhotoSize {
+  file_id: string;
+  file_unique_id: string;
+  width: number;
+  height: number;
+  file_size?: number;
+}
+
+interface TelegramUpdate {
+  update_id: number;
+  message: TelegramMessage;
+}
+
+// ── Helpers internos ──────────────────────────────────────────────────────────
+
+function baseMessage(fromUserId: number): TelegramMessage {
+  return {
+    message_id: nextMessageId(),
+    from: { id: fromUserId, is_bot: false, first_name: 'E2E Test' },
+    chat: { id: fromUserId, type: 'private' },
+    date: nowUnix(),
+  };
+}
+
+// ── Factories exportadas ──────────────────────────────────────────────────────
+
+export interface TextoPuroParams {
+  fromUserId: number;
+  text: string;
+}
+
+/**
+ * Update com mensagem de texto puro (sem foto, sem legenda).
+ * Usado para testar o handler genérico — não deve criar pedido.
+ */
+export function telegramUpdateTextoPuro({
+  fromUserId,
+  text,
+}: TextoPuroParams): TelegramUpdate {
+  return {
+    update_id: nextUpdateId(),
+    message: {
+      ...baseMessage(fromUserId),
+      text,
+    },
+  };
+}
+
+export interface StickerParams {
+  fromUserId: number;
+}
+
+/**
+ * Update com sticker.
+ * Usado para testar handler genérico (BE-15) — não deve criar pedido.
+ */
+export function telegramUpdateSticker({ fromUserId }: StickerParams): TelegramUpdate {
+  return {
+    update_id: nextUpdateId(),
+    message: {
+      ...baseMessage(fromUserId),
+      sticker: {
+        file_id: 'CAACAgIAAxkBAAE_e2e_sticker_fake',
+        file_unique_id: 'e2e_sticker_unique',
+        type: 'regular',
+        width: 512,
+        height: 512,
+        is_animated: false,
+        is_video: false,
+      },
+    },
+  };
+}
+
+// TODO Fase 1.1: adicionar telegramUpdateFotoLegenda após decisão de mock (ADR 00XX)
+// export function telegramUpdateFotoLegenda(...): TelegramUpdate { ... }

--- a/frontend/e2e/tsconfig.json
+++ b/frontend/e2e/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig.app.json",
   "compilerOptions": {
     "moduleResolution": "node",
-    "allowImportingTsExtensions": false,
+    "allowImportingTsExtensions": true,
     "noEmit": true,
     "types": ["node"]
   },


### PR DESCRIPTION
…m (#85)

Cria 4 helpers de infraestrutura E2E em frontend/e2e/fixtures/:
- banco.ts: conexão mysql2/promise com requisitante 99 como sentinel; garantirRequisitanteE2E (idempotente), limparDadosE2E (DELETE só req 99), semearPedidos, querySql, fecharConexao
- auth.ts: loginE2E — fluxo magic link completo (POST convite admin API, exchange, injeção de cookie finbot_session no contexto Playwright)
- global-setup.ts: substitui stub de QA-001; valida .env.e2e existente, falha ruidosamente se ausente, chama garantirRequisitanteE2E
- payloads-telegram.ts: 2 factories de Update sintético (textoPuro, sticker); TODO comentado para telegramUpdateFotoLegenda (aguarda ADR de mock de mídia)

Remove frontend/e2e/fixtures/.gitkeep (placeholder de QA-001). Corrige e2e/tsconfig.json: allowImportingTsExtensions false→true (TS5097).