### PR TITLE
fix(QA-008): workers serializados + update_id int32-safe

### DIFF
--- a/docs/sprints/03-folha-pagamento/status/QA-008-estabilizacao-suite-e2e-workers-e-update-id.md
+++ b/docs/sprints/03-folha-pagamento/status/QA-008-estabilizacao-suite-e2e-workers-e-update-id.md
@@ -1,0 +1,123 @@
+---
+task: QA-008
+titulo: "Estabilização da suíte E2E — workers serializados + update_id em int32"
+data: 2026-06-04
+branch: feature/qa-008-estabilizacao-suite-e2e
+responsavel: claude-front
+estado: parcial
+gates:
+  build: ok
+  lint: ok
+  testes: ok
+  testes_total: 61
+  testes_novos: 0
+  cobertura_pct: na
+  branch_convencao: ok
+  territorio: ok
+e2e_full:
+  exigido: true
+  executado: false
+  status: nao-aplicavel
+  specs_total: null
+  specs_passed: null
+  specs_failed: null
+  duracao_segundos: null
+  data_execucao: null
+commits:
+  - 031d55a
+pr: https://github.com/SSteringS/financas_bot_telegram/pull/93
+desvios: 0
+pendencias_humano: 1
+---
+
+# QA-008 — Estabilização da suíte E2E (workers serializados + update_id em int32)
+
+---
+
+## O que foi feito
+
+Duas mudanças mecânicas que corrigem os dois bugs que causaram falhas na primeira execução real da suíte E2E em 2026-06-04.
+
+### Bug A — `frontend/playwright.config.ts`: `workers: 1`
+
+Adicionado `workers: 1` ao `defineConfig`, com comentário de 3 linhas explicando:
+- Por que: todos os specs compartilham `requisitante_id=99`; workers paralelos causam race condition entre `beforeEach` de specs distintos.
+- Caminho de saída: quando a suíte crescer, refatorar para requisitantes distintos por spec.
+
+### Bug B — `frontend/e2e/fixtures/payloads-telegram.ts`: gerador int32-safe
+
+Substituído `Date.now()` por `Math.floor(Math.random() * 1_000_000_000)` como base do contador de `update_id`.
+
+Justificativa registrada em comentário:
+- `Date.now()` retorna ~1.78×10¹² (milissegundos epoch), que excede max-int32 (2.147×10⁹).
+- O backend usa `org.telegram.telegrambots.meta.api.objects.Update`, que deserializa `update_id` como `Integer` — consistente com a spec oficial do Telegram Bot API que define `update_id` como "32-bit integer".
+- Base aleatória até 10⁹ deixa ~1.1×10⁹ de folga antes de estourar — mais que suficiente para qualquer suíte real.
+- Aleatoriedade reduz colisão entre runs em `mensagem_processada` (tabela não é limpa pelo E2E por design — ver `banco.ts:91`).
+
+---
+
+## Validações realizadas
+
+| Validação | Resultado |
+|---|---|
+| `npm test` (Vitest) 61/61 | ✓ zero regressão |
+| `npm run lint` | ✓ limpo |
+| `npm run build` | ✓ exit 0 |
+| `npx tsc -p e2e/tsconfig.json --noEmit` | ✓ sem erros |
+| `workers: 1` presente em `playwright.config.ts` com comentário | ✓ |
+| `update_id` gerado por `Math.floor(Math.random() * 1_000_000_000)` | ✓ cabe em int32 |
+| `Date.now()` ausente no gerador de `update_id` | ✓ |
+
+**Gate pendente (requer ambiente local):**
+- `npm run e2e:full` verde 3x consecutivas — **não executado nesta sessão** (requer MySQL + backend + frontend rodando). Marcado como `pendencias_humano: 1`.
+
+Esta validação é o **critério duro** do plano. O status permanece `parcial` até o humano confirmar as 3 execuções e atualizar o frontmatter (`e2e_full.executado: true`, `e2e_full.status: verde`, etc.).
+
+---
+
+## Desvios do plano
+
+Nenhum.
+
+---
+
+## Decisões tomadas durante a execução
+
+**Comentário de 3 linhas em `playwright.config.ts`:** o plano exige comentário explicativo para `workers: 1`. Optei por 3 linhas (motivo + caminho de saída) em vez de 1 linha para registrar tanto o "por quê agora" quanto o "como escalar no futuro", evitando que alguém remova o `workers: 1` sem entender o trade-off.
+
+**Comentário de 6 linhas em `payloads-telegram.ts`:** detalhado propositalmente — documenta a spec do Telegram, o range do int32, e a referência ao `banco.ts:91`. Serve como documentação inline permanente do invariante, para qualquer futuro mantenedor que olhe o arquivo.
+
+---
+
+## Decisões pendentes (esperando humano)
+
+1. **Validação `e2e:full` 3x consecutivas:** rodar `cd frontend && npm run e2e:full` 3 vezes em ambiente limpo (MySQL + back + front). Se tudo verde, atualizar este status report:
+   ```yaml
+   estado: concluido
+   e2e_full:
+     exigido: true
+     executado: true
+     status: verde
+     specs_total: 2
+     specs_passed: 2   # (3 testes nos 2 specs)
+     specs_failed: 0
+     duracao_segundos: <medir>
+     data_execucao: <YYYY-MM-DDTHH:MM:SSZ>
+   pendencias_humano: 0
+   ```
+   E adicionar seção "Evidência E2E" com o resultado das 3 execuções.
+
+---
+
+## Próximos passos / observações
+
+- Após validação: task fecha, QA-006 (gate no PRE-MERGE-CHECKLIST) fica desbloqueada.
+- **Confirmar no log do backend** que `JsonMappingException: Numeric value (...) out of range of int` **não aparece mais** durante a execução — é o sinal de que o Bug B foi resolvido de ponta a ponta.
+- Se `npm run e2e:full` ainda falhar após as correções: investigar logs do Playwright (`playwright-report/`) e do backend para identificar nova causa raiz.
+
+---
+
+## Arquivos criados/modificados
+
+- `frontend/playwright.config.ts` (modificado: adiciona `workers: 1` com comentário)
+- `frontend/e2e/fixtures/payloads-telegram.ts` (modificado: substitui `Date.now()` por gerador int32-safe)

--- a/frontend/e2e/fixtures/payloads-telegram.ts
+++ b/frontend/e2e/fixtures/payloads-telegram.ts
@@ -14,8 +14,14 @@
  */
 
 // ── Contador de update_id (único por execução) ────────────────────────────────
+//
+// Base aleatória em int32: a Telegram Bot API define update_id como Integer (32-bit).
+// Date.now() (~1.78e12) estoura o max-int32 (2.147e9) e causa JsonMappingException no backend.
+// Base random até 10^9 deixa folga de ~1.1e9 incrementos antes de estourar — suficiente.
+// Aleatoriedade reduz colisão com runs anteriores em mensagem_processada (não é limpa pelo E2E).
+// Ref: https://core.telegram.org/bots/api#update ("Integer — The update's unique identifier")
 
-let _updateCounter = Date.now();
+let _updateCounter = Math.floor(Math.random() * 1_000_000_000);
 
 function nextUpdateId(): number {
   return _updateCounter++;

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -9,6 +9,10 @@ export default defineConfig({
   globalSetup: './e2e/fixtures/global-setup.ts',
   outputDir: './playwright-report',
   reporter: [['html', { outputFolder: 'playwright-report' }], ['list']],
+  // workers: 1 — todos os specs compartilham requisitante_id=99; paralelismo causa race condition
+  // (worker A semeia pedidos, worker B faz limparDadosE2E e apaga tudo antes do A terminar).
+  // Quando a suíte crescer e precisar de paralelo, refatorar para requisitantes distintos por spec.
+  workers: 1,
   use: {
     baseURL: process.env['E2E_FRONTEND_URL'] ?? 'http://localhost:5173',
     trace: 'on-first-retry',


### PR DESCRIPTION
## Summary

Corrige 2 bugs que causaram falha na primeira execução real da suíte E2E (2026-06-04):

**Bug A — Race condition entre workers paralelos**
- `playwright.config.ts`: adicionado `workers: 1` (com comentário explicativo)
- Causa: todos os specs compartilham `requisitante_id=99`; `limparDadosE2E()` de um worker apagava pedidos semeados pelo outro

**Bug B — `update_id` estourando int32**
- `payloads-telegram.ts`: substituído `Date.now()` (~1.78×10¹²) por `Math.floor(Math.random() * 1_000_000_000)`
- Causa: Telegram Bot API define `update_id` como Integer (32-bit); `Date.now()` excede max-int32 (2.147×10⁹) → `JsonMappingException` no backend

## Gate pendente

`exige_e2e_full: true` — validação de `npm run e2e:full` 3x consecutivas requer ambiente local (MySQL + backend + frontend). **Status: parcial.** Humano valida e fecha o gate.

## Test plan

- [x] `npm test` (Vitest) — 61/61 verdes
- [x] `npm run lint` — limpo
- [x] `npm run build` — exit 0
- [x] `npx tsc -p e2e/tsconfig.json --noEmit` — sem erros
- [ ] `npm run e2e:full` verde 3x consecutivas — pendente (requer ambiente local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)