### PR TITLE
feat(BE-024): entidades JPA + repositórios — Funcionario e Adiantamento

### DIFF
--- a/docs/sprints/03-folha-pagamento/status/BE-024-entidades-jpa-repositorios-folha.md
+++ b/docs/sprints/03-folha-pagamento/status/BE-024-entidades-jpa-repositorios-folha.md
@@ -1,0 +1,121 @@
+---
+task: BE-024
+titulo: "Entidades JPA + repositórios — Funcionario e Adiantamento"
+data: 2026-06-04
+branch: feature/be-024-entidades-jpa-repositorios-folha
+responsavel: claude-back
+estado: concluido
+gates:
+  build: ok
+  lint: ok
+  testes: ok
+  testes_total: 300
+  testes_novos: 12
+  cobertura_pct: na
+  branch_convencao: ok
+  territorio: ok
+commits:
+  - placeholder
+pr: null
+desvios: 0
+pendencias_humano: 0
+---
+
+# BE-024 — Entidades JPA + repositórios — Funcionario e Adiantamento
+
+## O que foi feito
+
+- Criados enums de domínio `FormaPagamento` (PIX/TED) e `CategoriaPedido` (VALE/FOLHA) em `domain/vo/` com Javadoc explicitando ortogonalidade entre si e com `TipoPagamento`.
+- Criados POJOs de domínio `Funcionario` e `Adiantamento` em `domain/entity/` — sem anotações JPA.
+- Criados ports de saída `FuncionarioRepositoryPortOut` e `AdiantamentoRepositoryPortOut` em `application/port/out/` — interfaces puras.
+- Estendido `PedidoPagamentoRepositoryPort` com 4 novos métodos: `findValesAbertos`, `existsFolha`, `markAllClosed`, `findFolhasByFuncionario`.
+- Criadas entidades JPA `FuncionarioEntity` e `AdiantamentoEntity` mapeando todas as colunas da V6.
+- Criados `FuncionarioJpaRepository` e `AdiantamentoJpaRepository` (Spring Data JPA).
+- Criados adapters `FuncionarioRepositoryAdapter` e `AdiantamentoRepositoryAdapter` implementando os ports.
+- Criados mappers `FuncionarioMapper` e `AdiantamentoMapper` com round-trip entity↔domain.
+- Adicionados 5 campos V6 em `PedidoPagamentoEntity` (categoria, funcionario_id, fechado, observacao, mes_referencia).
+- Adicionados campos equivalentes em `PedidoPagamento` (domínio) e atualizados mapper e JPA repository para suportá-los.
+- `mvn test` verde: 300 testes, 0 falhas, 12 novos.
+
+---
+
+## Desvios do plano
+
+Nenhum.
+
+---
+
+## Decisões tomadas durante a execução
+
+**`PedidoPagamentoRepositoryPort` (não `PedidoRepositoryPortOut`):** O plano referencia "PedidoRepositoryPortOut" mas o arquivo existente é `PedidoPagamentoRepositoryPort`. Mantido o nome existente — renomear quebraria referências e não agrega valor.
+
+**`requisitante_id` NOT NULL:** Verificado: `PedidoPagamentoEntity.requisitanteId` tem `nullable = false`. Para pedidos FOLHA (categoria=FOLHA), o `requisitante_id` precisará ser populado com um valor sentinel ou a coluna tornada nullable. **Decisão adiada para BE-028**, onde o FecharMesUseCase cria o Pedido FOLHA — o status report de BE-028 deve registrar a solução escolhida.
+
+**`tipoConta` como String na entity JPA:** A tabela tem `ENUM('CORRENTE','POUPANCA')` mas mapeamos como `String` na entity para evitar criar um enum JPA separado (o domínio usa String também). O banco aplica a restrição de enum; o código Java valida no use case de cadastro de funcionário (BE-025).
+
+**Soft delete na `deleteById`:** O adapter implementa `ativo=false` em vez de DELETE físico, alinhado com o padrão do projeto.
+
+---
+
+## Decisões pendentes (esperando humano)
+
+Nenhuma — tarefa fechada.
+
+---
+
+## Próximos passos / observações pro próximo
+
+- **BE-025, BE-026, BE-027 podem rodar em paralelo** agora que as entidades e ports existem.
+- **`requisitante_id` NOT NULL** é um ponto de atenção para BE-028: ao criar Pedido FOLHA, o use case precisará resolver o valor de `requisitante_id`. Opções: (a) nullable via ALTER TABLE V6b; (b) valor sentinel (ex: `0L`). Ver plano BE-028 §"Verificar (pré-implementação)".
+- A tabela `adiantamento` tem CHECK constraint `chk_adiant_consistencia` — o BE-027 deve validar `|valorTotal - valorParcela * numParcelas| <= 0.01` **antes** de chegar no banco, conforme plano.
+
+---
+
+## Padrões técnicos
+
+**SRP (Single Responsibility Principle):**
+- `FuncionarioMapper` (mapper/) — única responsabilidade: traduzir entity↔domain. Não conhece ports nem use cases.
+- `FuncionarioRepositoryAdapter` (adapters/out/) — única responsabilidade: implementar o port de saída. Não conhece nenhum use case.
+
+**DIP (Dependency Inversion Principle):**
+- `FuncionarioRepositoryPortOut` e `AdiantamentoRepositoryPortOut` são interfaces puras (sem anotações Spring) em `application/port/out/`. Use cases futuros (BE-025..028) dependerão dessas interfaces, não das implementações JPA.
+- O domínio (`domain/entity/Funcionario.java`, `domain/entity/Adiantamento.java`) não importa nenhuma classe de `adapters/` — isolamento total.
+
+**OCP (Open/Closed Principle):**
+- `PedidoPagamentoRepositoryPort` foi estendido com 4 novos métodos sem quebrar os existentes (`save`, `findById`). A implementação `PedidoPagamentoRepositoryAdapter` foi estendida de forma aditiva.
+
+**Arquitetura hexagonal:**
+- Domínio (`domain/entity/`, `domain/vo/`): POJOs puros — zero dependências de frameworks.
+- Application layer (`application/port/out/`): interfaces puras — definem o contrato sem vincular à implementação.
+- Adapters out (`adapters/out/persistence/`): única camada que conhece JPA, Spring Data e Hibernate.
+- O fluxo de dependência é sempre de fora para dentro: `AdiantamentoRepositoryAdapter` → `AdiantamentoRepositoryPortOut` ← use cases futuros. O adapter implementa o port; o use case depende do port — nunca do adapter diretamente.
+
+**Javadoc ortogonalidade `CategoriaPedido` vs `TipoPagamento`:**
+- Comentário explícito em `CategoriaPedido.java` e `FormaPagamento.java` documentando que são dimensões independentes — endereça o risco identificado no plano.
+
+---
+
+## Arquivos criados/modificados
+
+- `domain/vo/FormaPagamento.java` (novo)
+- `domain/vo/CategoriaPedido.java` (novo)
+- `domain/entity/Funcionario.java` (novo)
+- `domain/entity/Adiantamento.java` (novo)
+- `application/port/out/FuncionarioRepositoryPortOut.java` (novo)
+- `application/port/out/AdiantamentoRepositoryPortOut.java` (novo)
+- `application/port/out/PedidoPagamentoRepositoryPort.java` (modificado: +4 métodos V6)
+- `adapters/out/persistence/entity/FuncionarioEntity.java` (novo)
+- `adapters/out/persistence/entity/AdiantamentoEntity.java` (novo)
+- `adapters/out/persistence/entity/PedidoPagamentoEntity.java` (modificado: +5 campos V6)
+- `adapters/out/persistence/FuncionarioJpaRepository.java` (novo)
+- `adapters/out/persistence/AdiantamentoJpaRepository.java` (novo)
+- `adapters/out/persistence/FuncionarioRepositoryAdapter.java` (novo)
+- `adapters/out/persistence/AdiantamentoRepositoryAdapter.java` (novo)
+- `adapters/out/persistence/PedidoPagamentoJpaRepository.java` (modificado: +4 queries V6)
+- `adapters/out/persistence/PedidoPagamentoRepositoryAdapter.java` (modificado: +4 métodos V6)
+- `adapters/out/persistence/mapper/FuncionarioMapper.java` (novo)
+- `adapters/out/persistence/mapper/AdiantamentoMapper.java` (novo)
+- `adapters/out/persistence/mapper/PedidoPagamentoMapper.java` (modificado: V6 fields)
+- `domain/model/PedidoPagamento.java` (modificado: +5 campos V6)
+- `test/.../mapper/FuncionarioMapperTest.java` (novo — 6 testes)
+- `test/.../mapper/AdiantamentoMapperTest.java` (novo — 6 testes)

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/AdiantamentoJpaRepository.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/AdiantamentoJpaRepository.java
@@ -1,0 +1,12 @@
+package br.com.satyan.stering.saita.financasbottelegram.adapters.out.persistence;
+
+import br.com.satyan.stering.saita.financasbottelegram.adapters.out.persistence.entity.AdiantamentoEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AdiantamentoJpaRepository extends JpaRepository<AdiantamentoEntity, Long> {
+
+    List<AdiantamentoEntity> findByFuncionarioIdAndAtivoTrue(Long funcionarioId);
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/AdiantamentoRepositoryAdapter.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/AdiantamentoRepositoryAdapter.java
@@ -1,0 +1,57 @@
+package br.com.satyan.stering.saita.financasbottelegram.adapters.out.persistence;
+
+import br.com.satyan.stering.saita.financasbottelegram.adapters.out.persistence.entity.AdiantamentoEntity;
+import br.com.satyan.stering.saita.financasbottelegram.adapters.out.persistence.mapper.AdiantamentoMapper;
+import br.com.satyan.stering.saita.financasbottelegram.application.port.out.AdiantamentoRepositoryPortOut;
+import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Adiantamento;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+/**
+ * Adapter de persistência para {@link Adiantamento}.
+ *
+ * <p>Implementa {@link AdiantamentoRepositoryPortOut} (port de saída) usando Spring Data JPA.
+ * Única classe que conhece {@link AdiantamentoJpaRepository} — domínio e use cases
+ * dependem apenas do port (DIP).
+ */
+@Component
+public class AdiantamentoRepositoryAdapter implements AdiantamentoRepositoryPortOut {
+
+    private final AdiantamentoJpaRepository jpaRepository;
+    private final AdiantamentoMapper mapper;
+
+    public AdiantamentoRepositoryAdapter(
+            AdiantamentoJpaRepository jpaRepository,
+            AdiantamentoMapper mapper) {
+        this.jpaRepository = jpaRepository;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public Adiantamento save(Adiantamento adiantamento) {
+        AdiantamentoEntity entity = mapper.toEntity(adiantamento);
+        AdiantamentoEntity saved = jpaRepository.save(entity);
+        return mapper.toDomain(saved);
+    }
+
+    @Override
+    public Optional<Adiantamento> findById(Long id) {
+        return jpaRepository.findById(id).map(mapper::toDomain);
+    }
+
+    @Override
+    public List<Adiantamento> findAtivosParaFuncionario(Long funcionarioId) {
+        return jpaRepository.findByFuncionarioIdAndAtivoTrue(funcionarioId).stream()
+                .map(mapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<Adiantamento> findAtivosParaFechamento(Long funcionarioId) {
+        // Retorna todos os adiantamentos ativos — o FecharMesUseCase filtra por parcelas restantes
+        return jpaRepository.findByFuncionarioIdAndAtivoTrue(funcionarioId).stream()
+                .map(mapper::toDomain)
+                .toList();
+    }
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/FuncionarioJpaRepository.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/FuncionarioJpaRepository.java
@@ -1,0 +1,15 @@
+package br.com.satyan.stering.saita.financasbottelegram.adapters.out.persistence;
+
+import br.com.satyan.stering.saita.financasbottelegram.adapters.out.persistence.entity.FuncionarioEntity;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FuncionarioJpaRepository extends JpaRepository<FuncionarioEntity, Long> {
+
+    Optional<FuncionarioEntity> findByIdAndAtivoTrue(Long id);
+
+    List<FuncionarioEntity> findAllByAtivoTrue();
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/FuncionarioRepositoryAdapter.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/FuncionarioRepositoryAdapter.java
@@ -1,0 +1,63 @@
+package br.com.satyan.stering.saita.financasbottelegram.adapters.out.persistence;
+
+import br.com.satyan.stering.saita.financasbottelegram.adapters.out.persistence.entity.FuncionarioEntity;
+import br.com.satyan.stering.saita.financasbottelegram.adapters.out.persistence.mapper.FuncionarioMapper;
+import br.com.satyan.stering.saita.financasbottelegram.application.port.out.FuncionarioRepositoryPortOut;
+import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Funcionario;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+/**
+ * Adapter de persistência para {@link Funcionario}.
+ *
+ * <p>Implementa {@link FuncionarioRepositoryPortOut} (port de saída) usando Spring Data JPA.
+ * Única classe que conhece {@link FuncionarioJpaRepository} — domínio e use cases
+ * dependem apenas do port (DIP).
+ */
+@Component
+public class FuncionarioRepositoryAdapter implements FuncionarioRepositoryPortOut {
+
+    private final FuncionarioJpaRepository jpaRepository;
+    private final FuncionarioMapper mapper;
+
+    public FuncionarioRepositoryAdapter(
+            FuncionarioJpaRepository jpaRepository,
+            FuncionarioMapper mapper) {
+        this.jpaRepository = jpaRepository;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public Funcionario save(Funcionario funcionario) {
+        FuncionarioEntity entity = mapper.toEntity(funcionario);
+        FuncionarioEntity saved = jpaRepository.save(entity);
+        return mapper.toDomain(saved);
+    }
+
+    @Override
+    public Optional<Funcionario> findById(Long id) {
+        return jpaRepository.findById(id).map(mapper::toDomain);
+    }
+
+    @Override
+    public Optional<Funcionario> findAtivoById(Long id) {
+        return jpaRepository.findByIdAndAtivoTrue(id).map(mapper::toDomain);
+    }
+
+    @Override
+    public List<Funcionario> findAllAtivos() {
+        return jpaRepository.findAllByAtivoTrue().stream()
+                .map(mapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        // Soft delete: set ativo=false
+        jpaRepository.findById(id).ifPresent(entity -> {
+            entity.setAtivo(false);
+            jpaRepository.save(entity);
+        });
+    }
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/PedidoPagamentoJpaRepository.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/PedidoPagamentoJpaRepository.java
@@ -5,9 +5,11 @@ import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface PedidoPagamentoJpaRepository
@@ -43,4 +45,34 @@ public interface PedidoPagamentoJpaRepository
             @Param("inicioMes") LocalDate inicioMes,
             @Param("fimMes") LocalDate fimMes,
             @Param("buscaPattern") String buscaPattern);
+
+    // ── Métodos V6: folha de pagamento ────────────────────────────────────────
+
+    @Query("""
+           SELECT p FROM PedidoPagamentoEntity p
+           WHERE p.funcionarioId = :funcionarioId
+             AND p.categoria = br.com.satyan.stering.saita.financasbottelegram.domain.vo.CategoriaPedido.VALE
+             AND p.fechado = false
+             AND p.dataPedido >= :inicio
+             AND p.dataPedido <= :fim
+           """)
+    List<PedidoPagamentoEntity> findValesAbertos(
+            @Param("funcionarioId") Long funcionarioId,
+            @Param("inicio") LocalDate inicio,
+            @Param("fim") LocalDate fim);
+
+    boolean existsByFuncionarioIdAndMesReferencia(Long funcionarioId, LocalDate mesReferencia);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE PedidoPagamentoEntity p SET p.fechado = true WHERE p.id IN :ids")
+    void markAllClosed(@Param("ids") List<Long> ids);
+
+    @Query("""
+           SELECT p FROM PedidoPagamentoEntity p
+           WHERE p.funcionarioId = :funcionarioId
+             AND p.categoria = br.com.satyan.stering.saita.financasbottelegram.domain.vo.CategoriaPedido.FOLHA
+           ORDER BY p.mesReferencia DESC
+           """)
+    List<PedidoPagamentoEntity> findFolhasByFuncionario(@Param("funcionarioId") Long funcionarioId);
 }

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/PedidoPagamentoRepositoryAdapter.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/PedidoPagamentoRepositoryAdapter.java
@@ -4,6 +4,8 @@ import br.com.satyan.stering.saita.financasbottelegram.adapters.out.persistence.
 import br.com.satyan.stering.saita.financasbottelegram.adapters.out.persistence.mapper.PedidoPagamentoMapper;
 import br.com.satyan.stering.saita.financasbottelegram.application.port.out.PedidoPagamentoRepositoryPort;
 import br.com.satyan.stering.saita.financasbottelegram.domain.model.PedidoPagamento;
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.stereotype.Component;
 
@@ -30,5 +32,30 @@ public class PedidoPagamentoRepositoryAdapter implements PedidoPagamentoReposito
     @Override
     public Optional<PedidoPagamento> findById(Long id) {
         return jpaRepository.findById(id).map(mapper::toDomain);
+    }
+
+    @Override
+    public List<PedidoPagamento> findValesAbertos(Long funcionarioId, LocalDate inicio, LocalDate fim) {
+        return jpaRepository.findValesAbertos(funcionarioId, inicio, fim).stream()
+                .map(mapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public boolean existsFolha(Long funcionarioId, LocalDate mesReferencia) {
+        return jpaRepository.existsByFuncionarioIdAndMesReferencia(funcionarioId, mesReferencia);
+    }
+
+    @Override
+    public void markAllClosed(List<Long> pedidoIds) {
+        if (pedidoIds == null || pedidoIds.isEmpty()) return;
+        jpaRepository.markAllClosed(pedidoIds);
+    }
+
+    @Override
+    public List<PedidoPagamento> findFolhasByFuncionario(Long funcionarioId) {
+        return jpaRepository.findFolhasByFuncionario(funcionarioId).stream()
+                .map(mapper::toDomain)
+                .toList();
     }
 }

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/entity/AdiantamentoEntity.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/entity/AdiantamentoEntity.java
@@ -1,0 +1,49 @@
+package br.com.satyan.stering.saita.financasbottelegram.adapters.out.persistence.entity;
+
+import jakarta.persistence.*;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "adiantamento")
+public class AdiantamentoEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "funcionario_id", nullable = false)
+    private Long funcionarioId;
+
+    @Column(name = "descricao", nullable = false, length = 255)
+    private String descricao;
+
+    @Column(name = "valor_total", nullable = false, precision = 10, scale = 2)
+    private BigDecimal valorTotal;
+
+    @Column(name = "valor_parcela", nullable = false, precision = 10, scale = 2)
+    private BigDecimal valorParcela;
+
+    @Column(name = "num_parcelas", nullable = false)
+    private Integer numParcelas;
+
+    @Column(name = "parcelas_pagas", nullable = false)
+    private Integer parcelasPagas = 0;
+
+    @Column(name = "data_inicio", nullable = false)
+    private LocalDate dataInicio;
+
+    @Column(name = "ativo", nullable = false)
+    private Boolean ativo = true;
+
+    @CreationTimestamp
+    @Column(name = "criado_em", updatable = false, nullable = false)
+    private LocalDateTime criadoEm;
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/entity/FuncionarioEntity.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/entity/FuncionarioEntity.java
@@ -1,0 +1,72 @@
+package br.com.satyan.stering.saita.financasbottelegram.adapters.out.persistence.entity;
+
+import br.com.satyan.stering.saita.financasbottelegram.domain.vo.FormaPagamento;
+import jakarta.persistence.*;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "funcionario")
+public class FuncionarioEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "nome", nullable = false, length = 120)
+    private String nome;
+
+    @Column(name = "salario_base", nullable = false, precision = 10, scale = 2)
+    private BigDecimal salarioBase;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "forma_pagamento", nullable = false)
+    private FormaPagamento formaPagamento;
+
+    @Column(name = "chave_pix", length = 255)
+    private String chavePix;
+
+    @Column(name = "banco", length = 50)
+    private String banco;
+
+    @Column(name = "agencia", length = 20)
+    private String agencia;
+
+    @Column(name = "conta", length = 30)
+    private String conta;
+
+    /** CORRENTE ou POUPANCA — mapeado como String para evitar enum adicional no domínio JPA. */
+    @Column(name = "tipo_conta")
+    private String tipoConta;
+
+    @Column(name = "conta_propria", nullable = false)
+    private Boolean contaPropria = true;
+
+    @Column(name = "obs_pagamento", length = 500)
+    private String obsPagamento;
+
+    @Column(name = "dia_pagamento_referencia")
+    private Integer diaPagamentoReferencia;
+
+    @Column(name = "ativo", nullable = false)
+    private Boolean ativo = true;
+
+    @CreationTimestamp
+    @Column(name = "criado_em", updatable = false, nullable = false)
+    private LocalDateTime criadoEm;
+
+    /**
+     * Atualizado automaticamente pelo banco ({@code ON UPDATE CURRENT_TIMESTAMP}).
+     * Importante para rastreabilidade de alterações de salário.
+     */
+    @UpdateTimestamp
+    @Column(name = "atualizado_em", nullable = false)
+    private LocalDateTime atualizadoEm;
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/entity/PedidoPagamentoEntity.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/entity/PedidoPagamentoEntity.java
@@ -2,6 +2,7 @@ package br.com.satyan.stering.saita.financasbottelegram.adapters.out.persistence
 
 import br.com.satyan.stering.saita.financasbottelegram.domain.enums.StatusPedido;
 import br.com.satyan.stering.saita.financasbottelegram.domain.enums.TipoPagamento;
+import br.com.satyan.stering.saita.financasbottelegram.domain.vo.CategoriaPedido;
 import jakarta.persistence.*;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -58,4 +59,33 @@ public class PedidoPagamentoEntity {
     @CreationTimestamp
     @Column(name = "data_criacao", updatable = false)
     private LocalDateTime dataCriacao;
+
+    // ── Campos V6: folha de pagamento (STI) ──────────────────────────────────
+
+    /** Categoria do pedido no contexto da folha — null para pedidos normais do Telegram. */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "categoria")
+    private CategoriaPedido categoria;
+
+    /** FK para {@code funcionario.id} — obrigatório quando categoria não é null. */
+    @Column(name = "funcionario_id")
+    private Long funcionarioId;
+
+    /**
+     * Indica se o vale já foi considerado no fechamento do mês.
+     * {@code false} para vales abertos; {@code true} após o {@code FecharMesUseCase}.
+     */
+    @Column(name = "fechado", nullable = false)
+    private Boolean fechado = false;
+
+    /** Breakdown legível do cálculo da folha (preenchido apenas para categoria=FOLHA). */
+    @Column(name = "observacao", columnDefinition = "VARCHAR(1000)")
+    private String observacao;
+
+    /**
+     * Mês de referência do fechamento (primeiro dia do mês — ex: 2026-05-01).
+     * Obrigatório para categoria=FOLHA; null para VALE e pedidos normais.
+     */
+    @Column(name = "mes_referencia")
+    private LocalDate mesReferencia;
 }

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/mapper/AdiantamentoMapper.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/mapper/AdiantamentoMapper.java
@@ -1,0 +1,46 @@
+package br.com.satyan.stering.saita.financasbottelegram.adapters.out.persistence.mapper;
+
+import br.com.satyan.stering.saita.financasbottelegram.adapters.out.persistence.entity.AdiantamentoEntity;
+import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Adiantamento;
+import org.springframework.stereotype.Component;
+
+/**
+ * Mapper entre {@link AdiantamentoEntity} (JPA) e {@link Adiantamento} (domínio).
+ *
+ * <p>Garante que a camada de domínio permaneça livre de anotações JPA.
+ */
+@Component
+public class AdiantamentoMapper {
+
+    public Adiantamento toDomain(AdiantamentoEntity entity) {
+        if (entity == null) return null;
+        return Adiantamento.builder()
+                .id(entity.getId())
+                .funcionarioId(entity.getFuncionarioId())
+                .descricao(entity.getDescricao())
+                .valorTotal(entity.getValorTotal())
+                .valorParcela(entity.getValorParcela())
+                .numParcelas(entity.getNumParcelas())
+                .parcelasPagas(entity.getParcelasPagas())
+                .dataInicio(entity.getDataInicio())
+                .ativo(entity.getAtivo())
+                .criadoEm(entity.getCriadoEm())
+                .build();
+    }
+
+    public AdiantamentoEntity toEntity(Adiantamento domain) {
+        if (domain == null) return null;
+        AdiantamentoEntity entity = new AdiantamentoEntity();
+        entity.setId(domain.getId());
+        entity.setFuncionarioId(domain.getFuncionarioId());
+        entity.setDescricao(domain.getDescricao());
+        entity.setValorTotal(domain.getValorTotal());
+        entity.setValorParcela(domain.getValorParcela());
+        entity.setNumParcelas(domain.getNumParcelas());
+        entity.setParcelasPagas(domain.getParcelasPagas() != null ? domain.getParcelasPagas() : 0);
+        entity.setDataInicio(domain.getDataInicio());
+        entity.setAtivo(domain.getAtivo() != null ? domain.getAtivo() : true);
+        // criadoEm gerenciado pelo banco/Hibernate
+        return entity;
+    }
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/mapper/FuncionarioMapper.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/mapper/FuncionarioMapper.java
@@ -1,0 +1,56 @@
+package br.com.satyan.stering.saita.financasbottelegram.adapters.out.persistence.mapper;
+
+import br.com.satyan.stering.saita.financasbottelegram.adapters.out.persistence.entity.FuncionarioEntity;
+import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Funcionario;
+import org.springframework.stereotype.Component;
+
+/**
+ * Mapper entre {@link FuncionarioEntity} (JPA) e {@link Funcionario} (domínio).
+ *
+ * <p>Mantém isolamento da camada de persistência: o domínio não conhece {@link FuncionarioEntity}.
+ * O campo {@code atualizadoEm} é incluído no mapeamento para rastreabilidade de salário.
+ */
+@Component
+public class FuncionarioMapper {
+
+    public Funcionario toDomain(FuncionarioEntity entity) {
+        if (entity == null) return null;
+        return Funcionario.builder()
+                .id(entity.getId())
+                .nome(entity.getNome())
+                .salarioBase(entity.getSalarioBase())
+                .formaPagamento(entity.getFormaPagamento())
+                .chavePix(entity.getChavePix())
+                .banco(entity.getBanco())
+                .agencia(entity.getAgencia())
+                .conta(entity.getConta())
+                .tipoConta(entity.getTipoConta())
+                .contaPropria(entity.getContaPropria())
+                .obsPagamento(entity.getObsPagamento())
+                .diaPagamentoReferencia(entity.getDiaPagamentoReferencia())
+                .ativo(entity.getAtivo())
+                .criadoEm(entity.getCriadoEm())
+                .atualizadoEm(entity.getAtualizadoEm())
+                .build();
+    }
+
+    public FuncionarioEntity toEntity(Funcionario domain) {
+        if (domain == null) return null;
+        FuncionarioEntity entity = new FuncionarioEntity();
+        entity.setId(domain.getId());
+        entity.setNome(domain.getNome());
+        entity.setSalarioBase(domain.getSalarioBase());
+        entity.setFormaPagamento(domain.getFormaPagamento());
+        entity.setChavePix(domain.getChavePix());
+        entity.setBanco(domain.getBanco());
+        entity.setAgencia(domain.getAgencia());
+        entity.setConta(domain.getConta());
+        entity.setTipoConta(domain.getTipoConta());
+        entity.setContaPropria(domain.getContaPropria() != null ? domain.getContaPropria() : true);
+        entity.setObsPagamento(domain.getObsPagamento());
+        entity.setDiaPagamentoReferencia(domain.getDiaPagamentoReferencia());
+        entity.setAtivo(domain.getAtivo() != null ? domain.getAtivo() : true);
+        // criadoEm e atualizadoEm são gerenciados pelo banco/Hibernate
+        return entity;
+    }
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/mapper/PedidoPagamentoMapper.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/mapper/PedidoPagamentoMapper.java
@@ -23,6 +23,12 @@ public class PedidoPagamentoMapper {
                 .dataPedido(entity.getDataPedido())
                 .dataPagamento(entity.getDataPagamento())
                 .dataCriacao(entity.getDataCriacao())
+                // V6: folha de pagamento
+                .categoria(entity.getCategoria())
+                .funcionarioId(entity.getFuncionarioId())
+                .fechado(entity.getFechado())
+                .observacao(entity.getObservacao())
+                .mesReferencia(entity.getMesReferencia())
                 .build();
     }
 
@@ -42,6 +48,12 @@ public class PedidoPagamentoMapper {
         entity.setDataPedido(domain.getDataPedido());
         entity.setDataPagamento(domain.getDataPagamento());
         entity.setDataCriacao(domain.getDataCriacao());
+        // V6: folha de pagamento
+        entity.setCategoria(domain.getCategoria());
+        entity.setFuncionarioId(domain.getFuncionarioId());
+        entity.setFechado(domain.getFechado() != null ? domain.getFechado() : false);
+        entity.setObservacao(domain.getObservacao());
+        entity.setMesReferencia(domain.getMesReferencia());
         return entity;
     }
 }

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/port/out/AdiantamentoRepositoryPortOut.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/port/out/AdiantamentoRepositoryPortOut.java
@@ -1,0 +1,27 @@
+package br.com.satyan.stering.saita.financasbottelegram.application.port.out;
+
+import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Adiantamento;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Port de saída para persistência de {@link Adiantamento}.
+ *
+ * <p>Interface pura — sem anotações Spring. Implementada pelo adapter JPA
+ * {@code AdiantamentoRepositoryAdapter}.
+ */
+public interface AdiantamentoRepositoryPortOut {
+
+    Adiantamento save(Adiantamento adiantamento);
+
+    Optional<Adiantamento> findById(Long id);
+
+    /** Retorna adiantamentos com {@code ativo=true} para o funcionário informado. */
+    List<Adiantamento> findAtivosParaFuncionario(Long funcionarioId);
+
+    /**
+     * Retorna adiantamentos ativos com parcelas a pagar no mês de referência.
+     * Usado pelo {@code FecharMesUseCase} para calcular descontos.
+     */
+    List<Adiantamento> findAtivosParaFechamento(Long funcionarioId);
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/port/out/FuncionarioRepositoryPortOut.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/port/out/FuncionarioRepositoryPortOut.java
@@ -1,0 +1,25 @@
+package br.com.satyan.stering.saita.financasbottelegram.application.port.out;
+
+import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Funcionario;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Port de saída para persistência de {@link Funcionario}.
+ *
+ * <p>Interface pura — sem anotações Spring. Implementada pelo adapter JPA
+ * {@code FuncionarioRepositoryAdapter}.
+ */
+public interface FuncionarioRepositoryPortOut {
+
+    Funcionario save(Funcionario funcionario);
+
+    Optional<Funcionario> findById(Long id);
+
+    /** Retorna apenas funcionários com {@code ativo=true}. */
+    Optional<Funcionario> findAtivoById(Long id);
+
+    List<Funcionario> findAllAtivos();
+
+    void deleteById(Long id);
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/port/out/PedidoPagamentoRepositoryPort.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/port/out/PedidoPagamentoRepositoryPort.java
@@ -1,9 +1,37 @@
 package br.com.satyan.stering.saita.financasbottelegram.application.port.out;
 
 import br.com.satyan.stering.saita.financasbottelegram.domain.model.PedidoPagamento;
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface PedidoPagamentoRepositoryPort {
+
     PedidoPagamento save(PedidoPagamento pedidoPagamento);
+
     Optional<PedidoPagamento> findById(Long id);
+
+    /**
+     * Retorna vales abertos ({@code categoria=VALE}, {@code fechado=false}) do funcionário
+     * cujo {@code data_pedido} esteja dentro do intervalo [inicio, fim] (inclusive).
+     */
+    List<PedidoPagamento> findValesAbertos(Long funcionarioId, LocalDate inicio, LocalDate fim);
+
+    /**
+     * Verifica se já existe um Pedido FOLHA para o funcionário no mês de referência.
+     * Usado pelo {@code FecharMesUseCase} para garantir idempotência (passo 1).
+     */
+    boolean existsFolha(Long funcionarioId, LocalDate mesReferencia);
+
+    /**
+     * Marca todos os pedidos da lista como {@code fechado=true}.
+     * Chamado pelo {@code FecharMesUseCase} após criar o Pedido FOLHA (passo 9).
+     */
+    void markAllClosed(List<Long> pedidoIds);
+
+    /**
+     * Lista todos os Pedidos FOLHA do funcionário, ordenados por {@code mes_referencia DESC}.
+     * Usado pelo endpoint {@code GET /api/funcionarios/{id}/fechamentos}.
+     */
+    List<PedidoPagamento> findFolhasByFuncionario(Long funcionarioId);
 }

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/domain/entity/Adiantamento.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/domain/entity/Adiantamento.java
@@ -1,0 +1,57 @@
+package br.com.satyan.stering.saita.financasbottelegram.domain.entity;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Plano de desconto parcelado concedido a um funcionário — entidade de domínio (POJO puro).
+ *
+ * <p>Um adiantamento é automaticamente quitado quando {@code parcelasPagas == numParcelas}.
+ * Pode ser cancelado manualmente (soft: {@code ativo=false}) antes da quitação.
+ *
+ * <p>Invariante matemática (verificada também no banco via CHECK constraint):
+ * {@code |valorTotal - valorParcela * numParcelas| <= 0.01}
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Adiantamento {
+
+    private Long id;
+
+    private Long funcionarioId;
+
+    private String descricao;
+
+    /** Valor total do adiantamento. */
+    private BigDecimal valorTotal;
+
+    /** Valor descontado por mês no fechamento. */
+    private BigDecimal valorParcela;
+
+    /** Número total de parcelas planejadas. */
+    private Integer numParcelas;
+
+    /** Parcelas já descontadas em fechamentos anteriores. Incrementado pelo FecharMesUseCase. */
+    private Integer parcelasPagas;
+
+    /** Data de início do plano (primeiro desconto previsto). */
+    private LocalDate dataInicio;
+
+    /**
+     * {@code true} enquanto ainda há parcelas a pagar ou o adiantamento não foi cancelado.
+     * Setado para {@code false} quando {@code parcelasPagas == numParcelas} (quitado)
+     * ou quando cancelado manualmente.
+     */
+    private Boolean ativo;
+
+    private LocalDateTime criadoEm;
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/domain/entity/Funcionario.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/domain/entity/Funcionario.java
@@ -1,0 +1,66 @@
+package br.com.satyan.stering.saita.financasbottelegram.domain.entity;
+
+import br.com.satyan.stering.saita.financasbottelegram.domain.vo.FormaPagamento;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Funcionário doméstico — entidade de domínio (POJO puro, sem anotações JPA).
+ *
+ * <p>Espelha a tabela {@code funcionario} criada na migração V6. Campos de pagamento são
+ * condicionais à {@link FormaPagamento}: PIX requer {@code chavePix}; TED requer
+ * {@code banco}, {@code agencia}, {@code conta} e {@code tipoConta}.
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Funcionario {
+
+    private Long id;
+
+    private String nome;
+
+    private BigDecimal salarioBase;
+
+    /** Canal financeiro para pagamento do salário — PIX ou TED. */
+    private FormaPagamento formaPagamento;
+
+    /** Obrigatório quando {@code formaPagamento == PIX}. */
+    private String chavePix;
+
+    /** Obrigatório quando {@code formaPagamento == TED}. */
+    private String banco;
+
+    /** Obrigatório quando {@code formaPagamento == TED}. */
+    private String agencia;
+
+    /** Obrigatório quando {@code formaPagamento == TED}. */
+    private String conta;
+
+    /** Obrigatório quando {@code formaPagamento == TED}. Valores: CORRENTE ou POUPANCA. */
+    private String tipoConta;
+
+    /** Indica se a conta bancária é em nome do funcionário. */
+    private Boolean contaPropria;
+
+    /** Observações sobre forma de pagamento (campo livre). */
+    private String obsPagamento;
+
+    /** Dia de referência para geração da folha (1–31, pode ser null). */
+    private Integer diaPagamentoReferencia;
+
+    /** {@code false} quando o funcionário é desativado (soft delete). */
+    private Boolean ativo;
+
+    private LocalDateTime criadoEm;
+
+    /** Atualizado automaticamente no banco; relevante para rastreabilidade de alterações de salário. */
+    private LocalDateTime atualizadoEm;
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/domain/model/PedidoPagamento.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/domain/model/PedidoPagamento.java
@@ -2,6 +2,7 @@ package br.com.satyan.stering.saita.financasbottelegram.domain.model;
 
 import br.com.satyan.stering.saita.financasbottelegram.domain.enums.StatusPedido;
 import br.com.satyan.stering.saita.financasbottelegram.domain.enums.TipoPagamento;
+import br.com.satyan.stering.saita.financasbottelegram.domain.vo.CategoriaPedido;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -30,4 +31,21 @@ public class PedidoPagamento {
     private LocalDate dataPedido;
     private LocalDate dataPagamento;
     private LocalDateTime dataCriacao;
+
+    // ── Campos V6: folha de pagamento (STI) ──────────────────────────────────
+
+    /** Categoria do pedido — null para pedidos normais do Telegram. */
+    private CategoriaPedido categoria;
+
+    /** ID do funcionário doméstico — obrigatório quando categoria não é null. */
+    private Long funcionarioId;
+
+    /** Vale marcado como fechado após o FecharMesUseCase. */
+    private Boolean fechado;
+
+    /** Breakdown do cálculo da folha (preenchido para categoria=FOLHA). */
+    private String observacao;
+
+    /** Primeiro dia do mês de referência — obrigatório para categoria=FOLHA. */
+    private LocalDate mesReferencia;
 }

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/domain/vo/CategoriaPedido.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/domain/vo/CategoriaPedido.java
@@ -1,0 +1,30 @@
+package br.com.satyan.stering.saita.financasbottelegram.domain.vo;
+
+/**
+ * Categoria de um pedido relacionado à folha de pagamento doméstica.
+ *
+ * <p><strong>Dimensão ortogonal a {@link FormaPagamento}:</strong> {@code FormaPagamento} descreve
+ * o canal financeiro (PIX/TED), enquanto {@code CategoriaPedido} descreve o <em>propósito</em> do
+ * registro na tabela {@code pedidos_pagamento} via Single-Table Inheritance (STI).
+ *
+ * <p>Também é ortogonal a {@code TipoPagamento} (que classifica pedidos do fluxo Telegram —
+ * ex.: {@code PIX}, {@code TED}). Os dois enums coexistem sem conflito: um pedido do tipo
+ * {@code FOLHA} não precisa ter {@code TipoPagamento} preenchido.
+ *
+ * <p>Pedidos SEM categoria (NULL) são pedidos normais do fluxo Telegram.
+ */
+public enum CategoriaPedido {
+
+    /**
+     * Vale concedido ao funcionário — desconto parcelado no fechamento do mês.
+     * Armazenado como {@code Pedido} com {@code fechado=false} até o fechamento.
+     */
+    VALE,
+
+    /**
+     * Registro de fechamento mensal da folha de pagamento.
+     * Contém o breakdown do cálculo em {@code observacao} e referência ao mês em
+     * {@code mes_referencia}. Unicidade garantida por {@code uq_folha_por_mes}.
+     */
+    FOLHA
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/domain/vo/FormaPagamento.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/domain/vo/FormaPagamento.java
@@ -1,0 +1,18 @@
+package br.com.satyan.stering.saita.financasbottelegram.domain.vo;
+
+/**
+ * Forma de pagamento do salário do funcionário.
+ *
+ * <p>Dimensão ortogonal a {@link CategoriaPedido}: enquanto {@code CategoriaPedido} descreve o
+ * <em>propósito</em> do pedido (vale de desconto vs. folha de pagamento), {@code FormaPagamento}
+ * descreve o <em>canal financeiro</em> utilizado para transferir dinheiro ao funcionário.
+ * Os dois enums são independentes e não se sobrepõem.
+ */
+public enum FormaPagamento {
+
+    /** Pagamento via chave PIX — requer {@code chave_pix} preenchida no cadastro. */
+    PIX,
+
+    /** Pagamento via TED — requer {@code banco}, {@code agencia}, {@code conta} e {@code tipo_conta}. */
+    TED
+}

--- a/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/mapper/AdiantamentoMapperTest.java
+++ b/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/mapper/AdiantamentoMapperTest.java
@@ -1,0 +1,124 @@
+package br.com.satyan.stering.saita.financasbottelegram.adapters.out.persistence.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import br.com.satyan.stering.saita.financasbottelegram.adapters.out.persistence.entity.AdiantamentoEntity;
+import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Adiantamento;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+class AdiantamentoMapperTest {
+
+    private final AdiantamentoMapper mapper = new AdiantamentoMapper();
+
+    @Test
+    void deveMapearEntityParaDomain() {
+        AdiantamentoEntity entity = new AdiantamentoEntity();
+        entity.setId(1L);
+        entity.setFuncionarioId(10L);
+        entity.setDescricao("Adiantamento de emergência");
+        entity.setValorTotal(new BigDecimal("600.00"));
+        entity.setValorParcela(new BigDecimal("200.00"));
+        entity.setNumParcelas(3);
+        entity.setParcelasPagas(1);
+        entity.setDataInicio(LocalDate.of(2026, 1, 1));
+        entity.setAtivo(true);
+        entity.setCriadoEm(LocalDateTime.of(2026, 1, 1, 9, 0));
+
+        Adiantamento domain = mapper.toDomain(entity);
+
+        assertThat(domain.getId()).isEqualTo(1L);
+        assertThat(domain.getFuncionarioId()).isEqualTo(10L);
+        assertThat(domain.getDescricao()).isEqualTo("Adiantamento de emergência");
+        assertThat(domain.getValorTotal()).isEqualByComparingTo("600.00");
+        assertThat(domain.getValorParcela()).isEqualByComparingTo("200.00");
+        assertThat(domain.getNumParcelas()).isEqualTo(3);
+        assertThat(domain.getParcelasPagas()).isEqualTo(1);
+        assertThat(domain.getDataInicio()).isEqualTo(LocalDate.of(2026, 1, 1));
+        assertThat(domain.getAtivo()).isTrue();
+        assertThat(domain.getCriadoEm()).isEqualTo(LocalDateTime.of(2026, 1, 1, 9, 0));
+    }
+
+    @Test
+    void deveMapearDomainParaEntity() {
+        Adiantamento domain = Adiantamento.builder()
+                .id(2L)
+                .funcionarioId(20L)
+                .descricao("Empréstimo")
+                .valorTotal(new BigDecimal("1000.00"))
+                .valorParcela(new BigDecimal("500.00"))
+                .numParcelas(2)
+                .parcelasPagas(0)
+                .dataInicio(LocalDate.of(2026, 3, 1))
+                .ativo(true)
+                .build();
+
+        AdiantamentoEntity entity = mapper.toEntity(domain);
+
+        assertThat(entity.getId()).isEqualTo(2L);
+        assertThat(entity.getFuncionarioId()).isEqualTo(20L);
+        assertThat(entity.getDescricao()).isEqualTo("Empréstimo");
+        assertThat(entity.getValorTotal()).isEqualByComparingTo("1000.00");
+        assertThat(entity.getValorParcela()).isEqualByComparingTo("500.00");
+        assertThat(entity.getNumParcelas()).isEqualTo(2);
+        assertThat(entity.getParcelasPagas()).isEqualTo(0);
+        assertThat(entity.getAtivo()).isTrue();
+    }
+
+    @Test
+    void deveRetornarNullParaEntityNula() {
+        assertThat(mapper.toDomain(null)).isNull();
+    }
+
+    @Test
+    void deveRetornarNullParaDomainNulo() {
+        assertThat(mapper.toEntity(null)).isNull();
+    }
+
+    @Test
+    void devePreservarRoundTrip() {
+        Adiantamento original = Adiantamento.builder()
+                .id(5L)
+                .funcionarioId(15L)
+                .descricao("Material escolar")
+                .valorTotal(new BigDecimal("300.00"))
+                .valorParcela(new BigDecimal("100.00"))
+                .numParcelas(3)
+                .parcelasPagas(2)
+                .dataInicio(LocalDate.of(2026, 4, 1))
+                .ativo(true)
+                .build();
+
+        AdiantamentoEntity entity = mapper.toEntity(original);
+        Adiantamento roundTrip = mapper.toDomain(entity);
+
+        assertThat(roundTrip.getId()).isEqualTo(original.getId());
+        assertThat(roundTrip.getFuncionarioId()).isEqualTo(original.getFuncionarioId());
+        assertThat(roundTrip.getDescricao()).isEqualTo(original.getDescricao());
+        assertThat(roundTrip.getValorTotal()).isEqualByComparingTo(original.getValorTotal());
+        assertThat(roundTrip.getValorParcela()).isEqualByComparingTo(original.getValorParcela());
+        assertThat(roundTrip.getNumParcelas()).isEqualTo(original.getNumParcelas());
+        assertThat(roundTrip.getParcelasPagas()).isEqualTo(original.getParcelasPagas());
+        assertThat(roundTrip.getAtivo()).isEqualTo(original.getAtivo());
+    }
+
+    @Test
+    void deveUsarZeroParaParcelasPagasNullaNoEntity() {
+        Adiantamento domain = Adiantamento.builder()
+                .funcionarioId(1L)
+                .descricao("Teste")
+                .valorTotal(new BigDecimal("100.00"))
+                .valorParcela(new BigDecimal("100.00"))
+                .numParcelas(1)
+                .parcelasPagas(null) // null → deve ser 0 no entity
+                .dataInicio(LocalDate.of(2026, 1, 1))
+                .ativo(true)
+                .build();
+
+        AdiantamentoEntity entity = mapper.toEntity(domain);
+
+        assertThat(entity.getParcelasPagas()).isEqualTo(0);
+    }
+}

--- a/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/mapper/FuncionarioMapperTest.java
+++ b/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/mapper/FuncionarioMapperTest.java
@@ -1,0 +1,119 @@
+package br.com.satyan.stering.saita.financasbottelegram.adapters.out.persistence.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import br.com.satyan.stering.saita.financasbottelegram.adapters.out.persistence.entity.FuncionarioEntity;
+import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Funcionario;
+import br.com.satyan.stering.saita.financasbottelegram.domain.vo.FormaPagamento;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+class FuncionarioMapperTest {
+
+    private final FuncionarioMapper mapper = new FuncionarioMapper();
+
+    @Test
+    void deveMapearEntityParaDomain() {
+        FuncionarioEntity entity = new FuncionarioEntity();
+        entity.setId(1L);
+        entity.setNome("Maria");
+        entity.setSalarioBase(new BigDecimal("1800.00"));
+        entity.setFormaPagamento(FormaPagamento.PIX);
+        entity.setChavePix("123.456.789-00");
+        entity.setContaPropria(true);
+        entity.setAtivo(true);
+        entity.setCriadoEm(LocalDateTime.of(2026, 1, 1, 10, 0));
+        entity.setAtualizadoEm(LocalDateTime.of(2026, 5, 1, 10, 0));
+
+        Funcionario domain = mapper.toDomain(entity);
+
+        assertThat(domain.getId()).isEqualTo(1L);
+        assertThat(domain.getNome()).isEqualTo("Maria");
+        assertThat(domain.getSalarioBase()).isEqualByComparingTo("1800.00");
+        assertThat(domain.getFormaPagamento()).isEqualTo(FormaPagamento.PIX);
+        assertThat(domain.getChavePix()).isEqualTo("123.456.789-00");
+        assertThat(domain.getContaPropria()).isTrue();
+        assertThat(domain.getAtivo()).isTrue();
+        assertThat(domain.getCriadoEm()).isEqualTo(LocalDateTime.of(2026, 1, 1, 10, 0));
+        assertThat(domain.getAtualizadoEm()).isEqualTo(LocalDateTime.of(2026, 5, 1, 10, 0));
+    }
+
+    @Test
+    void deveMapearEntityTedParaDomain() {
+        FuncionarioEntity entity = new FuncionarioEntity();
+        entity.setId(2L);
+        entity.setNome("João");
+        entity.setSalarioBase(new BigDecimal("2200.00"));
+        entity.setFormaPagamento(FormaPagamento.TED);
+        entity.setBanco("001");
+        entity.setAgencia("1234");
+        entity.setConta("56789-0");
+        entity.setTipoConta("CORRENTE");
+        entity.setContaPropria(true);
+        entity.setAtivo(true);
+
+        Funcionario domain = mapper.toDomain(entity);
+
+        assertThat(domain.getFormaPagamento()).isEqualTo(FormaPagamento.TED);
+        assertThat(domain.getBanco()).isEqualTo("001");
+        assertThat(domain.getAgencia()).isEqualTo("1234");
+        assertThat(domain.getConta()).isEqualTo("56789-0");
+        assertThat(domain.getTipoConta()).isEqualTo("CORRENTE");
+    }
+
+    @Test
+    void deveMapearDomainParaEntity() {
+        Funcionario domain = Funcionario.builder()
+                .id(3L)
+                .nome("Ana")
+                .salarioBase(new BigDecimal("1500.00"))
+                .formaPagamento(FormaPagamento.PIX)
+                .chavePix("ana@pix.com")
+                .contaPropria(true)
+                .ativo(true)
+                .build();
+
+        FuncionarioEntity entity = mapper.toEntity(domain);
+
+        assertThat(entity.getId()).isEqualTo(3L);
+        assertThat(entity.getNome()).isEqualTo("Ana");
+        assertThat(entity.getSalarioBase()).isEqualByComparingTo("1500.00");
+        assertThat(entity.getFormaPagamento()).isEqualTo(FormaPagamento.PIX);
+        assertThat(entity.getChavePix()).isEqualTo("ana@pix.com");
+        assertThat(entity.getAtivo()).isTrue();
+    }
+
+    @Test
+    void deveRetornarNullParaEntityNula() {
+        assertThat(mapper.toDomain(null)).isNull();
+    }
+
+    @Test
+    void deveRetornarNullParaDomainNulo() {
+        assertThat(mapper.toEntity(null)).isNull();
+    }
+
+    @Test
+    void devePreservarRoundTripPix() {
+        Funcionario original = Funcionario.builder()
+                .id(4L)
+                .nome("Carlos")
+                .salarioBase(new BigDecimal("2000.00"))
+                .formaPagamento(FormaPagamento.PIX)
+                .chavePix("carlos@banco.com")
+                .contaPropria(true)
+                .ativo(true)
+                .build();
+
+        FuncionarioEntity entity = mapper.toEntity(original);
+        Funcionario roundTrip = mapper.toDomain(entity);
+
+        assertThat(roundTrip.getId()).isEqualTo(original.getId());
+        assertThat(roundTrip.getNome()).isEqualTo(original.getNome());
+        assertThat(roundTrip.getSalarioBase()).isEqualByComparingTo(original.getSalarioBase());
+        assertThat(roundTrip.getFormaPagamento()).isEqualTo(original.getFormaPagamento());
+        assertThat(roundTrip.getChavePix()).isEqualTo(original.getChavePix());
+        assertThat(roundTrip.getAtivo()).isEqualTo(original.getAtivo());
+    }
+}


### PR DESCRIPTION
## Summary

- Domínio: `Funcionario`, `Adiantamento` (POJOs), `FormaPagamento`, `CategoriaPedido` (enums)
- Ports out: `FuncionarioRepositoryPortOut`, `AdiantamentoRepositoryPortOut`
- `PedidoPagamentoRepositoryPort` estendido com 4 métodos V6: `findValesAbertos`, `existsFolha`, `markAllClosed`, `findFolhasByFuncionario`
- JPA entities: `FuncionarioEntity`, `AdiantamentoEntity`; `PedidoPagamentoEntity` +5 campos V6
- Adapters, mappers e JPA repositories criados
- 12 novos testes; `mvn test` 300/300 verdes

## Test plan
- [ ] `mvn test` verde (300 testes)
- [ ] Domínio livre de anotações JPA
- [ ] Ports são interfaces puras (sem `@Repository`, `@Autowired`)
- [ ] `PedidoPagamentoRepositoryPort` tem os 4 novos métodos
- [ ] `PedidoPagamentoEntity` tem os 5 campos V6

🤖 Generated with [Claude Code](https://claude.com/claude-code)