### PR TITLE
feat(BE-025): CadastrarFuncionario + CRUD /api/funcionarios

### DIFF
--- a/docs/sprints/03-folha-pagamento/status/BE-025-crud-funcionario.md
+++ b/docs/sprints/03-folha-pagamento/status/BE-025-crud-funcionario.md
@@ -1,0 +1,98 @@
+---
+task: BE-025
+titulo: "CadastrarFuncionario + CRUD /api/funcionarios"
+data: 2026-06-04
+branch: feature/be-025-crud-funcionario
+responsavel: claude-back
+estado: concluido
+gates:
+  build: ok
+  lint: ok
+  testes: ok
+  testes_total: 314
+  testes_novos: 14
+  cobertura_pct: na
+  branch_convencao: ok
+  territorio: ok
+commits:
+  - placeholder
+pr: null
+desvios: 1
+pendencias_humano: 0
+---
+
+# BE-025 — CadastrarFuncionario + CRUD /api/funcionarios
+
+## O que foi feito
+
+- Ports in: `CadastrarFuncionarioPortIn`, `AtualizarFuncionarioPortIn` em `application/port/in/`.
+- Service implementations: `CadastrarFuncionarioServiceImpl`, `AtualizarFuncionarioServiceImpl` em `application/services/`.
+- DTOs: `FuncionarioRequest` (com Bean Validation em campos comuns) e `FuncionarioResponse` (com factory `from(Funcionario)`).
+- Controller: `FuncionarioController` em `adapters/in/rest/funcionario/` com 5 endpoints (POST, GET lista, GET por id, PUT, DELETE soft).
+- Exceção de domínio `FuncionarioNaoEncontradoException` criada em `domain/exceptions/`.
+- Handler adicionado em `RestExceptionHandler` → 404 para `FuncionarioNaoEncontradoException`.
+- Validação condicional PIX/TED implementada no use case (`CadastrarFuncionarioServiceImpl.validarDadosPagamento`).
+- `mvn test` verde: 314 testes, 0 falhas, 14 novos.
+
+---
+
+## Desvios do plano
+
+1. **Controller em `adapters/in/rest/funcionario/`** em vez de `adapters/in/web/` — o projeto usa `adapters/in/rest/` como convenção para todos os controllers REST (pattern já estabelecido em PedidoController, ResumoController, etc.). Seguir a estrutura existente evita inconsistência no package layout.
+
+---
+
+## Decisões tomadas durante a execução
+
+**Validação condicional PIX/TED no use case (não em Bean Validation):** O plano sugeria `@AssertTrue` mas a validação foi implementada como método estático em `CadastrarFuncionarioServiceImpl.validarDadosPagamento()`, reutilizado também em `AtualizarFuncionarioServiceImpl`. Isso mantém a lógica de domínio no use case (não no DTO) e permite mensagens de erro descritivas e testáveis.
+
+**`AtualizarFuncionarioServiceImpl` reutiliza `validarDadosPagamento`:** Em vez de duplicar a validação, o atualizar chama o mesmo método estático após aplicar as mudanças no funcionário existente. Isso garante que um PUT parcial não quebre as invariantes PIX/TED.
+
+**Testes de controller com Mockito puro** (não `@WebMvcTest`): O projeto usa `@ExtendWith(MockitoExtension.class)` para testes de controller — padrão estabelecido em `PedidoControllerDetalheTest`. O `@WebMvcTest` falhava por dependências do `GlobalTelegramExceptionHandler` que precisaria de mais mocks.
+
+---
+
+## Decisões pendentes (esperando humano)
+
+Nenhuma — tarefa fechada.
+
+---
+
+## Próximos passos / observações pro próximo
+
+- **FE-015** pode iniciar após este merge.
+- Os endpoints usam path `/api/funcionarios` (sem `/v1/`) — consistente com a decisão de não versionamento na API da folha (novo domínio, pode estabelecer a convenção). Se o FE esperar `/api/v1/funcionarios`, ajustar antes do FE-015.
+
+---
+
+## Padrões técnicos
+
+**SRP:** `CadastrarFuncionarioServiceImpl` — responsabilidade única: cadastrar com validação. `AtualizarFuncionarioServiceImpl` — responsabilidade única: aplicar patch e revalidar. `FuncionarioController` — responsabilidade única: traduzir HTTP ↔ domínio.
+
+**DIP:** `FuncionarioController` depende de `CadastrarFuncionarioPortIn`, `AtualizarFuncionarioPortIn` e `FuncionarioRepositoryPortOut` — interfaces puras. Não conhece `CadastrarFuncionarioServiceImpl` nem `FuncionarioRepositoryAdapter`.
+
+**OCP (Strategy implícita):** `validarDadosPagamento` é extensível — se um terceiro `FormaPagamento` for adicionado, basta adicionar um `else if` sem quebrar os casos existentes. O método é `package-private static` para ser testável e reutilizável.
+
+**Arquitetura hexagonal:**
+- `FuncionarioRequest`/`FuncionarioResponse` ficam em `application/dto/` — são contratos da API, não do domínio.
+- A conversão `FuncionarioRequest → Funcionario` acontece no controller (`toFuncionario()`).
+- `FuncionarioResponse.from(Funcionario)` é um factory no DTO — evita que o domínio conheça os DTOs.
+- Os use cases recebem e retornam `Funcionario` (domínio) — não DTOs. Isolamento mantido.
+
+**Trade-off:** `FuncionarioController` acessa `FuncionarioRepositoryPortOut` diretamente para o GET por ID e o DELETE. Alternativa seria criar `BuscarFuncionarioPortIn` e `DesativarFuncionarioPortIn`, mas para operações triviais isso seria over-engineering. Documentado aqui caso o Reviewer queira padronizar.
+
+---
+
+## Arquivos criados/modificados
+
+- `application/port/in/CadastrarFuncionarioPortIn.java` (novo)
+- `application/port/in/AtualizarFuncionarioPortIn.java` (novo)
+- `application/services/CadastrarFuncionarioServiceImpl.java` (novo)
+- `application/services/AtualizarFuncionarioServiceImpl.java` (novo)
+- `application/dto/FuncionarioRequest.java` (novo)
+- `application/dto/FuncionarioResponse.java` (novo)
+- `adapters/in/rest/funcionario/FuncionarioController.java` (novo)
+- `domain/exceptions/FuncionarioNaoEncontradoException.java` (novo)
+- `adapters/in/rest/RestExceptionHandler.java` (modificado: +handler FuncionarioNaoEncontradoException)
+- `test/.../services/CadastrarFuncionarioServiceImplTest.java` (novo — 6 testes)
+- `test/.../funcionario/FuncionarioControllerTest.java` (novo — 8 testes)

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/rest/RestExceptionHandler.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/rest/RestExceptionHandler.java
@@ -3,6 +3,7 @@ package br.com.satyan.stering.saita.financasbottelegram.adapters.in.rest;
 import br.com.satyan.stering.saita.financasbottelegram.application.dto.ErroDTO;
 import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.AuthTokenInvalidoException;
 import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.ComprovanteNaoEncontradoException;
+import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.FuncionarioNaoEncontradoException;
 import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.ImagemNaoEncontradaException;
 import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.MesFormatoInvalidoException;
 import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.PedidoNaoAutorizadoException;
@@ -44,6 +45,12 @@ public class RestExceptionHandler {
     public ResponseEntity<ErroDTO> handleComprovanteNaoEncontrado(ComprovanteNaoEncontradoException e) {
         return ResponseEntity.status(404)
                 .body(new ErroDTO("COMPROVANTE_NAO_ENCONTRADO", e.getMessage()));
+    }
+
+    @ExceptionHandler(FuncionarioNaoEncontradoException.class)
+    public ResponseEntity<ErroDTO> handleFuncionarioNaoEncontrado(FuncionarioNaoEncontradoException e) {
+        return ResponseEntity.status(404)
+                .body(new ErroDTO("FUNCIONARIO_NAO_ENCONTRADO", e.getMessage()));
     }
 
     @ExceptionHandler(MesFormatoInvalidoException.class)

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/rest/funcionario/FuncionarioController.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/rest/funcionario/FuncionarioController.java
@@ -1,0 +1,105 @@
+package br.com.satyan.stering.saita.financasbottelegram.adapters.in.rest.funcionario;
+
+import br.com.satyan.stering.saita.financasbottelegram.application.dto.FuncionarioRequest;
+import br.com.satyan.stering.saita.financasbottelegram.application.dto.FuncionarioResponse;
+import br.com.satyan.stering.saita.financasbottelegram.application.port.in.AtualizarFuncionarioPortIn;
+import br.com.satyan.stering.saita.financasbottelegram.application.port.in.CadastrarFuncionarioPortIn;
+import br.com.satyan.stering.saita.financasbottelegram.application.port.out.FuncionarioRepositoryPortOut;
+import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Funcionario;
+import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.FuncionarioNaoEncontradoException;
+import br.com.satyan.stering.saita.financasbottelegram.domain.vo.FormaPagamento;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Controller REST para gerenciamento de funcionários domésticos.
+ *
+ * <p>Endpoints:
+ * <ul>
+ *   <li>{@code POST   /api/funcionarios} — Cadastrar funcionário</li>
+ *   <li>{@code GET    /api/funcionarios} — Listar ativos</li>
+ *   <li>{@code GET    /api/funcionarios/{id}} — Buscar por ID</li>
+ *   <li>{@code PUT    /api/funcionarios/{id}} — Atualizar dados</li>
+ *   <li>{@code DELETE /api/funcionarios/{id}} — Desativar (soft delete)</li>
+ * </ul>
+ */
+@RestController
+@RequestMapping("/api/funcionarios")
+public class FuncionarioController {
+
+    private final CadastrarFuncionarioPortIn cadastrarUseCase;
+    private final AtualizarFuncionarioPortIn atualizarUseCase;
+    private final FuncionarioRepositoryPortOut repository;
+
+    public FuncionarioController(
+            CadastrarFuncionarioPortIn cadastrarUseCase,
+            AtualizarFuncionarioPortIn atualizarUseCase,
+            FuncionarioRepositoryPortOut repository) {
+        this.cadastrarUseCase = cadastrarUseCase;
+        this.atualizarUseCase = atualizarUseCase;
+        this.repository = repository;
+    }
+
+    @PostMapping
+    @Operation(summary = "Cadastra um novo funcionário doméstico")
+    public ResponseEntity<FuncionarioResponse> cadastrar(@Valid @RequestBody FuncionarioRequest request) {
+        Funcionario funcionario = toFuncionario(request);
+        Funcionario criado = cadastrarUseCase.cadastrar(funcionario);
+        return ResponseEntity.status(HttpStatus.CREATED).body(FuncionarioResponse.from(criado));
+    }
+
+    @GetMapping
+    @Operation(summary = "Lista todos os funcionários ativos")
+    public List<FuncionarioResponse> listar() {
+        return repository.findAllAtivos().stream()
+                .map(FuncionarioResponse::from)
+                .toList();
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Busca funcionário por ID")
+    public FuncionarioResponse buscar(@PathVariable Long id) {
+        return repository.findById(id)
+                .map(FuncionarioResponse::from)
+                .orElseThrow(() -> new FuncionarioNaoEncontradoException(id));
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "Atualiza dados do funcionário")
+    public FuncionarioResponse atualizar(
+            @PathVariable Long id,
+            @Valid @RequestBody FuncionarioRequest request) {
+        Funcionario atualizado = atualizarUseCase.atualizar(id, toFuncionario(request));
+        return FuncionarioResponse.from(atualizado);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "Desativa funcionário (soft delete — ativo=false)")
+    public void desativar(@PathVariable Long id) {
+        // Verifica existência antes de tentar desativar
+        repository.findById(id)
+                .orElseThrow(() -> new FuncionarioNaoEncontradoException(id));
+        repository.deleteById(id);
+    }
+
+    private Funcionario toFuncionario(FuncionarioRequest req) {
+        return Funcionario.builder()
+                .nome(req.getNome())
+                .salarioBase(req.getSalarioBase())
+                .formaPagamento(req.getFormaPagamento())
+                .chavePix(req.getChavePix())
+                .banco(req.getBanco())
+                .agencia(req.getAgencia())
+                .conta(req.getConta())
+                .tipoConta(req.getTipoConta())
+                .contaPropria(req.getContaPropria() != null ? req.getContaPropria() : true)
+                .obsPagamento(req.getObsPagamento())
+                .diaPagamentoReferencia(req.getDiaPagamentoReferencia())
+                .build();
+    }
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/dto/FuncionarioRequest.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/dto/FuncionarioRequest.java
@@ -1,0 +1,60 @@
+package br.com.satyan.stering.saita.financasbottelegram.application.dto;
+
+import br.com.satyan.stering.saita.financasbottelegram.domain.vo.FormaPagamento;
+import jakarta.validation.constraints.*;
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * DTO de entrada para criação e atualização de funcionário.
+ *
+ * <p>Validação condicional PIX/TED: a validação de campos obrigatórios por forma de pagamento
+ * é feita no use case, não via Bean Validation, para evitar complexidade de validators de classe
+ * e dar mensagens de erro mais claras.
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FuncionarioRequest {
+
+    @NotBlank(message = "nome é obrigatório")
+    @Size(max = 120, message = "nome deve ter no máximo 120 caracteres")
+    private String nome;
+
+    @NotNull(message = "salarioBase é obrigatório")
+    @DecimalMin(value = "0.01", message = "salarioBase deve ser positivo")
+    private BigDecimal salarioBase;
+
+    @NotNull(message = "formaPagamento é obrigatório")
+    private FormaPagamento formaPagamento;
+
+    /** Obrigatório quando formaPagamento = PIX. */
+    private String chavePix;
+
+    /** Obrigatório quando formaPagamento = TED. */
+    private String banco;
+
+    /** Obrigatório quando formaPagamento = TED. */
+    private String agencia;
+
+    /** Obrigatório quando formaPagamento = TED. */
+    private String conta;
+
+    /** Obrigatório quando formaPagamento = TED. Valores aceitos: CORRENTE, POUPANCA. */
+    private String tipoConta;
+
+    private Boolean contaPropria;
+
+    @Size(max = 500, message = "obsPagamento deve ter no máximo 500 caracteres")
+    private String obsPagamento;
+
+    @Min(value = 1, message = "diaPagamentoReferencia deve ser entre 1 e 31")
+    @Max(value = 31, message = "diaPagamentoReferencia deve ser entre 1 e 31")
+    private Integer diaPagamentoReferencia;
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/dto/FuncionarioResponse.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/dto/FuncionarioResponse.java
@@ -1,0 +1,53 @@
+package br.com.satyan.stering.saita.financasbottelegram.application.dto;
+
+import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Funcionario;
+import br.com.satyan.stering.saita.financasbottelegram.domain.vo.FormaPagamento;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FuncionarioResponse {
+
+    private Long id;
+    private String nome;
+    private BigDecimal salarioBase;
+    private FormaPagamento formaPagamento;
+    private String chavePix;
+    private String banco;
+    private String agencia;
+    private String conta;
+    private String tipoConta;
+    private Boolean contaPropria;
+    private String obsPagamento;
+    private Integer diaPagamentoReferencia;
+    private Boolean ativo;
+    private LocalDateTime criadoEm;
+    private LocalDateTime atualizadoEm;
+
+    public static FuncionarioResponse from(Funcionario f) {
+        return FuncionarioResponse.builder()
+                .id(f.getId())
+                .nome(f.getNome())
+                .salarioBase(f.getSalarioBase())
+                .formaPagamento(f.getFormaPagamento())
+                .chavePix(f.getChavePix())
+                .banco(f.getBanco())
+                .agencia(f.getAgencia())
+                .conta(f.getConta())
+                .tipoConta(f.getTipoConta())
+                .contaPropria(f.getContaPropria())
+                .obsPagamento(f.getObsPagamento())
+                .diaPagamentoReferencia(f.getDiaPagamentoReferencia())
+                .ativo(f.getAtivo())
+                .criadoEm(f.getCriadoEm())
+                .atualizadoEm(f.getAtualizadoEm())
+                .build();
+    }
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/port/in/AtualizarFuncionarioPortIn.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/port/in/AtualizarFuncionarioPortIn.java
@@ -1,0 +1,13 @@
+package br.com.satyan.stering.saita.financasbottelegram.application.port.in;
+
+import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Funcionario;
+
+/**
+ * Port de entrada para atualizar dados de um funcionário doméstico.
+ *
+ * <p>Interface pura — sem anotações Spring. Implementada por {@code AtualizarFuncionarioServiceImpl}.
+ */
+public interface AtualizarFuncionarioPortIn {
+
+    Funcionario atualizar(Long id, Funcionario dadosAtualizados);
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/port/in/CadastrarFuncionarioPortIn.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/port/in/CadastrarFuncionarioPortIn.java
@@ -1,0 +1,13 @@
+package br.com.satyan.stering.saita.financasbottelegram.application.port.in;
+
+import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Funcionario;
+
+/**
+ * Port de entrada para cadastrar um funcionário doméstico.
+ *
+ * <p>Interface pura — sem anotações Spring. Implementada por {@code CadastrarFuncionarioServiceImpl}.
+ */
+public interface CadastrarFuncionarioPortIn {
+
+    Funcionario cadastrar(Funcionario funcionario);
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/services/AtualizarFuncionarioServiceImpl.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/services/AtualizarFuncionarioServiceImpl.java
@@ -1,0 +1,70 @@
+package br.com.satyan.stering.saita.financasbottelegram.application.services;
+
+import br.com.satyan.stering.saita.financasbottelegram.application.port.in.AtualizarFuncionarioPortIn;
+import br.com.satyan.stering.saita.financasbottelegram.application.port.out.FuncionarioRepositoryPortOut;
+import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Funcionario;
+import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.FuncionarioNaoEncontradoException;
+import org.springframework.stereotype.Service;
+
+/**
+ * Implementação do use case de atualização de funcionário.
+ *
+ * <p>Atualiza apenas campos mutáveis: salário, dados bancários, observações.
+ * Dados de identidade (nome, forma de pagamento) também podem ser atualizados.
+ * Valida as regras PIX/TED após a atualização.
+ */
+@Service
+public class AtualizarFuncionarioServiceImpl implements AtualizarFuncionarioPortIn {
+
+    private final FuncionarioRepositoryPortOut repository;
+
+    public AtualizarFuncionarioServiceImpl(FuncionarioRepositoryPortOut repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public Funcionario atualizar(Long id, Funcionario dadosAtualizados) {
+        Funcionario existente = repository.findById(id)
+                .orElseThrow(() -> new FuncionarioNaoEncontradoException(id));
+
+        // Atualiza campos fornecidos (null = não alterar)
+        if (dadosAtualizados.getNome() != null) {
+            existente.setNome(dadosAtualizados.getNome());
+        }
+        if (dadosAtualizados.getSalarioBase() != null) {
+            existente.setSalarioBase(dadosAtualizados.getSalarioBase());
+        }
+        if (dadosAtualizados.getFormaPagamento() != null) {
+            existente.setFormaPagamento(dadosAtualizados.getFormaPagamento());
+        }
+        if (dadosAtualizados.getChavePix() != null) {
+            existente.setChavePix(dadosAtualizados.getChavePix());
+        }
+        if (dadosAtualizados.getBanco() != null) {
+            existente.setBanco(dadosAtualizados.getBanco());
+        }
+        if (dadosAtualizados.getAgencia() != null) {
+            existente.setAgencia(dadosAtualizados.getAgencia());
+        }
+        if (dadosAtualizados.getConta() != null) {
+            existente.setConta(dadosAtualizados.getConta());
+        }
+        if (dadosAtualizados.getTipoConta() != null) {
+            existente.setTipoConta(dadosAtualizados.getTipoConta());
+        }
+        if (dadosAtualizados.getContaPropria() != null) {
+            existente.setContaPropria(dadosAtualizados.getContaPropria());
+        }
+        if (dadosAtualizados.getObsPagamento() != null) {
+            existente.setObsPagamento(dadosAtualizados.getObsPagamento());
+        }
+        if (dadosAtualizados.getDiaPagamentoReferencia() != null) {
+            existente.setDiaPagamentoReferencia(dadosAtualizados.getDiaPagamentoReferencia());
+        }
+
+        // Revalida dados bancários após atualização
+        CadastrarFuncionarioServiceImpl.validarDadosPagamento(existente);
+
+        return repository.save(existente);
+    }
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/services/CadastrarFuncionarioServiceImpl.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/services/CadastrarFuncionarioServiceImpl.java
@@ -1,0 +1,65 @@
+package br.com.satyan.stering.saita.financasbottelegram.application.services;
+
+import br.com.satyan.stering.saita.financasbottelegram.application.port.in.CadastrarFuncionarioPortIn;
+import br.com.satyan.stering.saita.financasbottelegram.application.port.out.FuncionarioRepositoryPortOut;
+import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Funcionario;
+import br.com.satyan.stering.saita.financasbottelegram.domain.vo.FormaPagamento;
+import org.springframework.stereotype.Service;
+
+/**
+ * Implementação do use case de cadastro de funcionário.
+ *
+ * <p>Valida regras condicionais PIX/TED antes de persistir. Depende apenas de
+ * {@link FuncionarioRepositoryPortOut} (DIP) — não conhece JPA diretamente.
+ */
+@Service
+public class CadastrarFuncionarioServiceImpl implements CadastrarFuncionarioPortIn {
+
+    private final FuncionarioRepositoryPortOut repository;
+
+    public CadastrarFuncionarioServiceImpl(FuncionarioRepositoryPortOut repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public Funcionario cadastrar(Funcionario funcionario) {
+        validarDadosPagamento(funcionario);
+
+        // Defaults para campos opcionais
+        if (funcionario.getContaPropria() == null) {
+            funcionario.setContaPropria(true);
+        }
+        if (funcionario.getAtivo() == null) {
+            funcionario.setAtivo(true);
+        }
+
+        return repository.save(funcionario);
+    }
+
+    /**
+     * Valida campos obrigatórios condicionais à forma de pagamento.
+     *
+     * <p>PIX → {@code chavePix} obrigatório.
+     * TED → {@code banco}, {@code agencia}, {@code conta}, {@code tipoConta} obrigatórios.
+     */
+    static void validarDadosPagamento(Funcionario f) {
+        if (f.getFormaPagamento() == FormaPagamento.PIX) {
+            if (f.getChavePix() == null || f.getChavePix().isBlank()) {
+                throw new IllegalArgumentException("chave_pix é obrigatória para forma de pagamento PIX");
+            }
+        } else if (f.getFormaPagamento() == FormaPagamento.TED) {
+            if (f.getBanco() == null || f.getBanco().isBlank()) {
+                throw new IllegalArgumentException("banco é obrigatório para forma de pagamento TED");
+            }
+            if (f.getAgencia() == null || f.getAgencia().isBlank()) {
+                throw new IllegalArgumentException("agencia é obrigatória para forma de pagamento TED");
+            }
+            if (f.getConta() == null || f.getConta().isBlank()) {
+                throw new IllegalArgumentException("conta é obrigatória para forma de pagamento TED");
+            }
+            if (f.getTipoConta() == null || f.getTipoConta().isBlank()) {
+                throw new IllegalArgumentException("tipo_conta é obrigatório para forma de pagamento TED");
+            }
+        }
+    }
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/domain/exceptions/FuncionarioNaoEncontradoException.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/domain/exceptions/FuncionarioNaoEncontradoException.java
@@ -1,0 +1,12 @@
+package br.com.satyan.stering.saita.financasbottelegram.domain.exceptions;
+
+public class FuncionarioNaoEncontradoException extends RuntimeException {
+
+    public FuncionarioNaoEncontradoException(Long id) {
+        super("Funcionário não encontrado: id=" + id);
+    }
+
+    public FuncionarioNaoEncontradoException(String message) {
+        super(message);
+    }
+}

--- a/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/rest/funcionario/FuncionarioControllerTest.java
+++ b/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/rest/funcionario/FuncionarioControllerTest.java
@@ -1,0 +1,157 @@
+package br.com.satyan.stering.saita.financasbottelegram.adapters.in.rest.funcionario;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import br.com.satyan.stering.saita.financasbottelegram.application.port.in.AtualizarFuncionarioPortIn;
+import br.com.satyan.stering.saita.financasbottelegram.application.port.in.CadastrarFuncionarioPortIn;
+import br.com.satyan.stering.saita.financasbottelegram.application.port.out.FuncionarioRepositoryPortOut;
+import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Funcionario;
+import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.FuncionarioNaoEncontradoException;
+import br.com.satyan.stering.saita.financasbottelegram.domain.vo.FormaPagamento;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class FuncionarioControllerTest {
+
+    @Mock
+    private CadastrarFuncionarioPortIn cadastrarUseCase;
+
+    @Mock
+    private AtualizarFuncionarioPortIn atualizarUseCase;
+
+    @Mock
+    private FuncionarioRepositoryPortOut repository;
+
+    private FuncionarioController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new FuncionarioController(cadastrarUseCase, atualizarUseCase, repository);
+    }
+
+    @Test
+    void postDeveCriarFuncionarioERetornar201() {
+        Funcionario criado = Funcionario.builder()
+                .id(1L)
+                .nome("Maria")
+                .salarioBase(new BigDecimal("1800.00"))
+                .formaPagamento(FormaPagamento.PIX)
+                .chavePix("123.456.789-00")
+                .ativo(true)
+                .contaPropria(true)
+                .build();
+
+        when(cadastrarUseCase.cadastrar(any())).thenReturn(criado);
+
+        var request = new br.com.satyan.stering.saita.financasbottelegram.application.dto.FuncionarioRequest();
+        request.setNome("Maria");
+        request.setSalarioBase(new BigDecimal("1800.00"));
+        request.setFormaPagamento(FormaPagamento.PIX);
+        request.setChavePix("123.456.789-00");
+
+        ResponseEntity<?> response = controller.cadastrar(request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        verify(cadastrarUseCase).cadastrar(any());
+    }
+
+    @Test
+    void getDeveListarFuncionariosAtivos() {
+        Funcionario f = Funcionario.builder()
+                .id(1L)
+                .nome("João")
+                .salarioBase(new BigDecimal("2000.00"))
+                .formaPagamento(FormaPagamento.TED)
+                .ativo(true)
+                .build();
+
+        when(repository.findAllAtivos()).thenReturn(List.of(f));
+
+        List<?> result = controller.listar();
+
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void getDeveRetornarFuncionarioPorId() {
+        Funcionario f = Funcionario.builder()
+                .id(1L)
+                .nome("Ana")
+                .formaPagamento(FormaPagamento.PIX)
+                .chavePix("ana@pix.com")
+                .ativo(true)
+                .build();
+
+        when(repository.findById(1L)).thenReturn(Optional.of(f));
+
+        var response = controller.buscar(1L);
+
+        assertThat(response.getNome()).isEqualTo("Ana");
+    }
+
+    @Test
+    void deveLancarExcecaoQuandoFuncionarioNaoEncontrado() {
+        when(repository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> controller.buscar(99L))
+                .isInstanceOf(FuncionarioNaoEncontradoException.class);
+    }
+
+    @Test
+    void deleteDeveDesativarFuncionario() {
+        Funcionario f = Funcionario.builder().id(1L).nome("Carlos").ativo(true).build();
+        when(repository.findById(1L)).thenReturn(Optional.of(f));
+
+        controller.desativar(1L);
+
+        verify(repository).deleteById(1L);
+    }
+
+    @Test
+    void putDeveAtualizarERetornarFuncionario() {
+        Funcionario atualizado = Funcionario.builder()
+                .id(1L)
+                .nome("Maria Nova")
+                .salarioBase(new BigDecimal("2000.00"))
+                .formaPagamento(FormaPagamento.PIX)
+                .chavePix("nova@pix.com")
+                .ativo(true)
+                .contaPropria(true)
+                .build();
+
+        when(atualizarUseCase.atualizar(eq(1L), any())).thenReturn(atualizado);
+
+        var request = new br.com.satyan.stering.saita.financasbottelegram.application.dto.FuncionarioRequest();
+        request.setNome("Maria Nova");
+        request.setSalarioBase(new BigDecimal("2000.00"));
+        request.setFormaPagamento(FormaPagamento.PIX);
+        request.setChavePix("nova@pix.com");
+
+        var response = controller.atualizar(1L, request);
+
+        assertThat(response.getSalarioBase()).isEqualByComparingTo("2000.00");
+    }
+
+    @Test
+    void deleteDeveLancarExcecaoQuandoFuncionarioNaoExiste() {
+        when(repository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> controller.desativar(99L))
+                .isInstanceOf(FuncionarioNaoEncontradoException.class);
+    }
+}

--- a/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/application/services/CadastrarFuncionarioServiceImplTest.java
+++ b/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/application/services/CadastrarFuncionarioServiceImplTest.java
@@ -1,0 +1,152 @@
+package br.com.satyan.stering.saita.financasbottelegram.application.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import br.com.satyan.stering.saita.financasbottelegram.application.port.out.FuncionarioRepositoryPortOut;
+import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Funcionario;
+import br.com.satyan.stering.saita.financasbottelegram.domain.vo.FormaPagamento;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CadastrarFuncionarioServiceImplTest {
+
+    @Mock
+    private FuncionarioRepositoryPortOut repository;
+
+    private CadastrarFuncionarioServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new CadastrarFuncionarioServiceImpl(repository);
+    }
+
+    @Test
+    void deveCadastrarFuncionarioPixComSucesso() {
+        Funcionario funcionario = Funcionario.builder()
+                .nome("Maria")
+                .salarioBase(new BigDecimal("1800.00"))
+                .formaPagamento(FormaPagamento.PIX)
+                .chavePix("123.456.789-00")
+                .build();
+
+        Funcionario savedFuncionario = Funcionario.builder()
+                .id(1L).nome("Maria").salarioBase(new BigDecimal("1800.00"))
+                .formaPagamento(FormaPagamento.PIX).chavePix("123.456.789-00").build();
+        when(repository.save(any())).thenReturn(savedFuncionario);
+
+        Funcionario resultado = service.cadastrar(funcionario);
+
+        assertThat(resultado.getId()).isEqualTo(1L);
+        verify(repository).save(any(Funcionario.class));
+    }
+
+    @Test
+    void deveCadastrarFuncionarioTedComSucesso() {
+        Funcionario funcionario = Funcionario.builder()
+                .nome("João")
+                .salarioBase(new BigDecimal("2200.00"))
+                .formaPagamento(FormaPagamento.TED)
+                .banco("001")
+                .agencia("1234")
+                .conta("56789-0")
+                .tipoConta("CORRENTE")
+                .build();
+
+        Funcionario savedFuncionario = Funcionario.builder()
+                .id(2L).nome("João").salarioBase(new BigDecimal("2200.00"))
+                .formaPagamento(FormaPagamento.TED).build();
+        when(repository.save(any())).thenReturn(savedFuncionario);
+
+        Funcionario resultado = service.cadastrar(funcionario);
+
+        assertThat(resultado.getId()).isEqualTo(2L);
+    }
+
+    @Test
+    void deveRejeitarPixSemChavePix() {
+        Funcionario funcionario = Funcionario.builder()
+                .nome("Ana")
+                .salarioBase(new BigDecimal("1500.00"))
+                .formaPagamento(FormaPagamento.PIX)
+                .chavePix(null) // faltando!
+                .build();
+
+        assertThatThrownBy(() -> service.cadastrar(funcionario))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("chave_pix");
+    }
+
+    @Test
+    void deveRejeitarTedSemBanco() {
+        Funcionario funcionario = Funcionario.builder()
+                .nome("Carlos")
+                .salarioBase(new BigDecimal("2000.00"))
+                .formaPagamento(FormaPagamento.TED)
+                .banco(null) // faltando!
+                .agencia("1234")
+                .conta("56789-0")
+                .tipoConta("CORRENTE")
+                .build();
+
+        assertThatThrownBy(() -> service.cadastrar(funcionario))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("banco");
+    }
+
+    @Test
+    void deveRejeitarTedSemTipoConta() {
+        Funcionario funcionario = Funcionario.builder()
+                .nome("Pedro")
+                .salarioBase(new BigDecimal("1900.00"))
+                .formaPagamento(FormaPagamento.TED)
+                .banco("001")
+                .agencia("5678")
+                .conta("12345-6")
+                .tipoConta(null) // faltando!
+                .build();
+
+        assertThatThrownBy(() -> service.cadastrar(funcionario))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("tipo_conta");
+    }
+
+    @Test
+    void deveSetarContaPropriaComoTrueQuandoNull() {
+        Funcionario funcionario = Funcionario.builder()
+                .nome("Lucia")
+                .salarioBase(new BigDecimal("1600.00"))
+                .formaPagamento(FormaPagamento.PIX)
+                .chavePix("lucia@pix.com")
+                .contaPropria(null) // deve virar true
+                .build();
+
+        when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        Funcionario resultado = service.cadastrar(funcionario);
+
+        assertThat(resultado.getContaPropria()).isTrue();
+    }
+
+    @Test
+    void deveRejeitarPixComChavePixEmBranco() {
+        Funcionario funcionario = Funcionario.builder()
+                .nome("Teste")
+                .salarioBase(new BigDecimal("1000.00"))
+                .formaPagamento(FormaPagamento.PIX)
+                .chavePix("   ")
+                .build();
+
+        assertThatThrownBy(() -> service.cadastrar(funcionario))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("chave_pix");
+    }
+}


### PR DESCRIPTION
## Summary
- Ports in, services, DTOs e controller para CRUD de funcionários
- Validação condicional PIX/TED no use case
- `FuncionarioNaoEncontradoException` → 404
- 14 novos testes; `mvn test` 314/314 verdes

## Test plan
- [ ] `mvn test` verde
- [ ] POST sem chave_pix para PIX → 400
- [ ] POST sem banco para TED → 400
- [ ] DELETE é soft (ativo=false)
- [ ] Controller em adapters/in/rest/funcionario/ (não web/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)