### PR TITLE
feat(BE-027): CadastrarAdiantamento + endpoints adiantamentos + cancelamento

### DIFF
--- a/docs/sprints/03-folha-pagamento/status/BE-027-cadastrar-adiantamento.md
+++ b/docs/sprints/03-folha-pagamento/status/BE-027-cadastrar-adiantamento.md
@@ -1,0 +1,95 @@
+---
+task: BE-027
+titulo: "CadastrarAdiantamento + endpoints adiantamentos + cancelamento"
+data: 2026-06-04
+branch: feature/be-027-cadastrar-adiantamento
+responsavel: claude-back
+estado: concluido
+gates:
+  build: ok
+  lint: ok
+  testes: ok
+  testes_total: 332
+  testes_novos: 12
+  cobertura_pct: na
+  branch_convencao: ok
+  territorio: ok
+commits:
+  - null
+pr: null
+desvios: 0
+pendencias_humano: 0
+---
+
+# BE-027 — CadastrarAdiantamento + endpoints adiantamentos + cancelamento
+
+## O que foi feito
+
+Entregues os dois use cases de adiantamento e três endpoints REST:
+
+- **`CadastrarAdiantamentoPortIn` / `CadastrarAdiantamentoServiceImpl`**: valida funcionário ativo, valida consistência matemática do plano (`|valorTotal - valorParcela × numParcelas| ≤ 0.01`), persiste com `parcelasPagas=0` e `ativo=true`.
+- **`CancelarAdiantamentoPortIn` / `CancelarAdiantamentoServiceImpl`**: verifica se adiantamento existe (404), se já está quitado (`parcelasPagas == numParcelas`) lança `AdiantamentoJaQuitadoException` (409), caso contrário faz soft cancel (`ativo=false`).
+- **DTOs**: `AdiantamentoRequest` (Bean Validation), `AdiantamentoResponse` (com campo calculado `parcelasRestantes`).
+- **`FolhaController`** atualizado com 3 endpoints: `POST /{id}/adiantamentos`, `GET /{id}/adiantamentos`, `DELETE /adiantamentos/{adiantamentoId}`.
+- **`RestExceptionHandler`** recebe handlers para `AdiantamentoNaoEncontradoException` → 404 e `AdiantamentoJaQuitadoException` → 409.
+- **Testes**: `CadastrarAdiantamentoServiceImplTest` (7 testes) e `CancelarAdiantamentoServiceImplTest` (5 testes) — 12 novos testes. Suite total: 332 testes, 0 falhas.
+
+---
+
+## Desvios do plano
+
+Nenhum.
+
+---
+
+## Decisões tomadas durante a execução
+
+- `validarConsistenciaMatemática` foi deixada com visibilidade package-private (`static void`) em vez de `private` para permitir teste direto sem instanciar o serviço com mocks — simplicidade de teste sem quebrar o encapsulamento do pacote.
+- O método `deveAceitarPlanoDentroDaToleranciaComArredondamento` testa o caso-limite exato (diferença = 0.01), confirmando que a condição é `<=` e não `<`.
+- `parcelasPagas = null` tratado como "nenhuma parcela paga" no cancelamento — o check `parcelasPagas.equals(numParcelas)` é protegido por null-check no `CancelarAdiantamentoServiceImpl`, evitando NPE.
+
+---
+
+## Decisões pendentes (esperando humano)
+
+Nenhuma — tarefa fechada.
+
+---
+
+## Próximos passos / observações pro próximo
+
+- **BE-028** pode iniciar. Precisa de `FecharMesUseCase` 11 passos `@Transactional`. Atenção à questão `requisitante_id NOT NULL` em `pedidos_pagamento` — ao criar o pedido FOLHA no fechamento, ou faz migration V6b pra tornar a coluna nullable, ou usa um valor sentinela. Decisão precisa ser tomada no início de BE-028.
+- `AdiantamentoRepositoryPortOut` está com `findAtivosParaFechamento(Long funcionarioId)` sem implementação ainda — BE-028 precisará implementar isso no adapter.
+
+---
+
+## Padrões técnicos (BE e FE: obrigatório; DEP/CI/EVO: omitir)
+
+**SOLID:**
+- **SRP**: `CadastrarAdiantamentoServiceImpl` faz só o cadastro; `CancelarAdiantamentoServiceImpl` faz só o cancelamento — nenhum serviço acumula responsabilidades.
+- **OCP / DIP**: ambos os serviços dependem de interfaces (`FuncionarioRepositoryPortOut`, `AdiantamentoRepositoryPortOut`) — nenhum conhece `JdbcTemplate`, `JpaRepository` ou qualquer detalhe de infraestrutura.
+
+**Design Patterns:**
+- **Fail-fast validation**: `validarConsistenciaMatemática` é chamada antes de qualquer acesso ao banco — mesma invariante está no CHECK constraint do banco, mas a validação antecipada evita que `DataIntegrityViolationException` vaze para a API com mensagem opaca.
+- **Soft delete**: `ativo=false` em vez de `DELETE` real — mesmo padrão usado em `FuncionarioRepositoryAdapter.deleteById()`. Preserva histórico de adiantamentos cancelados para eventual exibição no frontend.
+
+**Arquitetura hexagonal:**
+- `FolhaController` (adapter in) → chama `CadastrarAdiantamentoPortIn` / `CancelarAdiantamentoPortIn` (ports in) — nunca acessa `AdiantamentoRepositoryPortOut` para a operação de cancelamento diretamente; o controller chama o use case, que chama o port out.
+- Exceção: para o `GET /adiantamentos`, o controller chama `AdiantamentoRepositoryPortOut.findAtivosParaFuncionario()` diretamente (sem use case intermediário), igual ao que o `FolhaController` faz para `GET /vales`. Decisão consciente: consulta sem lógica de negócio não justifica use case próprio (trade-off de simplicidade vs. pureza hexagonal).
+
+---
+
+## Arquivos criados/modificados
+
+- `application/port/in/CadastrarAdiantamentoPortIn.java` (novo)
+- `application/port/in/CancelarAdiantamentoPortIn.java` (novo)
+- `application/services/CadastrarAdiantamentoServiceImpl.java` (novo)
+- `application/services/CancelarAdiantamentoServiceImpl.java` (novo)
+- `application/dto/AdiantamentoRequest.java` (novo)
+- `application/dto/AdiantamentoResponse.java` (novo)
+- `domain/exceptions/AdiantamentoNaoEncontradoException.java` (novo)
+- `domain/exceptions/AdiantamentoJaQuitadoException.java` (novo)
+- `adapters/in/rest/folha/FolhaController.java` (modificado: adicionados 3 endpoints de adiantamento)
+- `adapters/in/rest/RestExceptionHandler.java` (modificado: handlers 404 e 409 para adiantamento)
+- `test/.../CadastrarAdiantamentoServiceImplTest.java` (novo: 7 testes)
+- `test/.../CancelarAdiantamentoServiceImplTest.java` (novo: 5 testes)

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/rest/RestExceptionHandler.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/rest/RestExceptionHandler.java
@@ -1,6 +1,8 @@
 package br.com.satyan.stering.saita.financasbottelegram.adapters.in.rest;
 
 import br.com.satyan.stering.saita.financasbottelegram.application.dto.ErroDTO;
+import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.AdiantamentoJaQuitadoException;
+import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.AdiantamentoNaoEncontradoException;
 import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.AuthTokenInvalidoException;
 import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.ComprovanteNaoEncontradoException;
 import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.FuncionarioNaoEncontradoException;
@@ -51,6 +53,18 @@ public class RestExceptionHandler {
     public ResponseEntity<ErroDTO> handleFuncionarioNaoEncontrado(FuncionarioNaoEncontradoException e) {
         return ResponseEntity.status(404)
                 .body(new ErroDTO("FUNCIONARIO_NAO_ENCONTRADO", e.getMessage()));
+    }
+
+    @ExceptionHandler(AdiantamentoNaoEncontradoException.class)
+    public ResponseEntity<ErroDTO> handleAdiantamentoNaoEncontrado(AdiantamentoNaoEncontradoException e) {
+        return ResponseEntity.status(404)
+                .body(new ErroDTO("ADIANTAMENTO_NAO_ENCONTRADO", e.getMessage()));
+    }
+
+    @ExceptionHandler(AdiantamentoJaQuitadoException.class)
+    public ResponseEntity<ErroDTO> handleAdiantamentoJaQuitado(AdiantamentoJaQuitadoException e) {
+        return ResponseEntity.status(409)
+                .body(new ErroDTO("ADIANTAMENTO_JA_QUITADO", e.getMessage()));
     }
 
     @ExceptionHandler(MesFormatoInvalidoException.class)

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/rest/folha/FolhaController.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/rest/folha/FolhaController.java
@@ -1,9 +1,15 @@
 package br.com.satyan.stering.saita.financasbottelegram.adapters.in.rest.folha;
 
+import br.com.satyan.stering.saita.financasbottelegram.application.dto.AdiantamentoRequest;
+import br.com.satyan.stering.saita.financasbottelegram.application.dto.AdiantamentoResponse;
 import br.com.satyan.stering.saita.financasbottelegram.application.dto.ValeRequest;
 import br.com.satyan.stering.saita.financasbottelegram.application.dto.ValeResponse;
+import br.com.satyan.stering.saita.financasbottelegram.application.port.in.CadastrarAdiantamentoPortIn;
+import br.com.satyan.stering.saita.financasbottelegram.application.port.in.CancelarAdiantamentoPortIn;
 import br.com.satyan.stering.saita.financasbottelegram.application.port.in.CadastrarValePortIn;
+import br.com.satyan.stering.saita.financasbottelegram.application.port.out.AdiantamentoRepositoryPortOut;
 import br.com.satyan.stering.saita.financasbottelegram.application.port.out.PedidoPagamentoRepositoryPort;
+import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Adiantamento;
 import br.com.satyan.stering.saita.financasbottelegram.domain.model.PedidoPagamento;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -33,12 +39,21 @@ public class FolhaController {
 
     private final CadastrarValePortIn cadastrarValeUseCase;
     private final PedidoPagamentoRepositoryPort pedidoRepository;
+    private final CadastrarAdiantamentoPortIn cadastrarAdiantamentoUseCase;
+    private final CancelarAdiantamentoPortIn cancelarAdiantamentoUseCase;
+    private final AdiantamentoRepositoryPortOut adiantamentoRepository;
 
     public FolhaController(
             CadastrarValePortIn cadastrarValeUseCase,
-            PedidoPagamentoRepositoryPort pedidoRepository) {
+            PedidoPagamentoRepositoryPort pedidoRepository,
+            CadastrarAdiantamentoPortIn cadastrarAdiantamentoUseCase,
+            CancelarAdiantamentoPortIn cancelarAdiantamentoUseCase,
+            AdiantamentoRepositoryPortOut adiantamentoRepository) {
         this.cadastrarValeUseCase = cadastrarValeUseCase;
         this.pedidoRepository = pedidoRepository;
+        this.cadastrarAdiantamentoUseCase = cadastrarAdiantamentoUseCase;
+        this.cancelarAdiantamentoUseCase = cancelarAdiantamentoUseCase;
+        this.adiantamentoRepository = adiantamentoRepository;
     }
 
     // ── Vales ─────────────────────────────────────────────────────────────────
@@ -72,6 +87,41 @@ public class FolhaController {
         return pedidoRepository.findValesByFuncionarioAndPeriodo(id, inicio, fim).stream()
                 .map(ValeResponse::from)
                 .toList();
+    }
+
+    // ── Adiantamentos ─────────────────────────────────────────────────────────
+
+    @PostMapping("/{id}/adiantamentos")
+    @Operation(summary = "Cadastra um adiantamento parcelado para o funcionário")
+    public ResponseEntity<AdiantamentoResponse> cadastrarAdiantamento(
+            @PathVariable Long id,
+            @Valid @RequestBody AdiantamentoRequest request) {
+
+        Adiantamento adiantamento = Adiantamento.builder()
+                .descricao(request.getDescricao())
+                .valorTotal(request.getValorTotal())
+                .valorParcela(request.getValorParcela())
+                .numParcelas(request.getNumParcelas())
+                .dataInicio(request.getDataInicio())
+                .build();
+
+        Adiantamento criado = cadastrarAdiantamentoUseCase.cadastrar(id, adiantamento);
+        return ResponseEntity.status(HttpStatus.CREATED).body(AdiantamentoResponse.from(criado));
+    }
+
+    @GetMapping("/{id}/adiantamentos")
+    @Operation(summary = "Lista adiantamentos ativos do funcionário")
+    public List<AdiantamentoResponse> listarAdiantamentos(@PathVariable Long id) {
+        return adiantamentoRepository.findAtivosParaFuncionario(id).stream()
+                .map(AdiantamentoResponse::from)
+                .toList();
+    }
+
+    @DeleteMapping("/adiantamentos/{adiantamentoId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "Cancela (soft delete: ativo=false) um adiantamento")
+    public void cancelarAdiantamento(@PathVariable Long adiantamentoId) {
+        cancelarAdiantamentoUseCase.cancelar(adiantamentoId);
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/dto/AdiantamentoRequest.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/dto/AdiantamentoRequest.java
@@ -1,0 +1,39 @@
+package br.com.satyan.stering.saita.financasbottelegram.application.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdiantamentoRequest {
+
+    @NotBlank(message = "descricao é obrigatória")
+    private String descricao;
+
+    @NotNull(message = "valorTotal é obrigatório")
+    @DecimalMin(value = "0.01", message = "valorTotal deve ser positivo")
+    private BigDecimal valorTotal;
+
+    @NotNull(message = "valorParcela é obrigatório")
+    @DecimalMin(value = "0.01", message = "valorParcela deve ser positivo")
+    private BigDecimal valorParcela;
+
+    @NotNull(message = "numParcelas é obrigatório")
+    @Min(value = 1, message = "numParcelas deve ser pelo menos 1")
+    private Integer numParcelas;
+
+    @NotNull(message = "dataInicio é obrigatória")
+    private LocalDate dataInicio;
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/dto/AdiantamentoResponse.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/dto/AdiantamentoResponse.java
@@ -1,0 +1,48 @@
+package br.com.satyan.stering.saita.financasbottelegram.application.dto;
+
+import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Adiantamento;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdiantamentoResponse {
+
+    private Long id;
+    private Long funcionarioId;
+    private String descricao;
+    private BigDecimal valorTotal;
+    private BigDecimal valorParcela;
+    private Integer numParcelas;
+    private Integer parcelasPagas;
+    private Integer parcelasRestantes;
+    private LocalDate dataInicio;
+    private Boolean ativo;
+    private LocalDateTime criadoEm;
+
+    public static AdiantamentoResponse from(Adiantamento a) {
+        int restantes = (a.getNumParcelas() != null && a.getParcelasPagas() != null)
+                ? a.getNumParcelas() - a.getParcelasPagas()
+                : 0;
+        return AdiantamentoResponse.builder()
+                .id(a.getId())
+                .funcionarioId(a.getFuncionarioId())
+                .descricao(a.getDescricao())
+                .valorTotal(a.getValorTotal())
+                .valorParcela(a.getValorParcela())
+                .numParcelas(a.getNumParcelas())
+                .parcelasPagas(a.getParcelasPagas())
+                .parcelasRestantes(restantes)
+                .dataInicio(a.getDataInicio())
+                .ativo(a.getAtivo())
+                .criadoEm(a.getCriadoEm())
+                .build();
+    }
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/port/in/CadastrarAdiantamentoPortIn.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/port/in/CadastrarAdiantamentoPortIn.java
@@ -1,0 +1,11 @@
+package br.com.satyan.stering.saita.financasbottelegram.application.port.in;
+
+import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Adiantamento;
+
+/**
+ * Port de entrada para cadastrar um plano de adiantamento parcelado.
+ */
+public interface CadastrarAdiantamentoPortIn {
+
+    Adiantamento cadastrar(Long funcionarioId, Adiantamento adiantamento);
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/port/in/CancelarAdiantamentoPortIn.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/port/in/CancelarAdiantamentoPortIn.java
@@ -1,0 +1,9 @@
+package br.com.satyan.stering.saita.financasbottelegram.application.port.in;
+
+/**
+ * Port de entrada para cancelar um adiantamento ativo (soft cancel: ativo=false).
+ */
+public interface CancelarAdiantamentoPortIn {
+
+    void cancelar(Long adiantamentoId);
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/services/CadastrarAdiantamentoServiceImpl.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/services/CadastrarAdiantamentoServiceImpl.java
@@ -1,0 +1,79 @@
+package br.com.satyan.stering.saita.financasbottelegram.application.services;
+
+import br.com.satyan.stering.saita.financasbottelegram.application.port.in.CadastrarAdiantamentoPortIn;
+import br.com.satyan.stering.saita.financasbottelegram.application.port.out.AdiantamentoRepositoryPortOut;
+import br.com.satyan.stering.saita.financasbottelegram.application.port.out.FuncionarioRepositoryPortOut;
+import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Adiantamento;
+import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.FuncionarioNaoEncontradoException;
+import java.math.BigDecimal;
+import org.springframework.stereotype.Service;
+
+/**
+ * Implementação do use case de cadastro de adiantamento.
+ *
+ * <p>Valida:
+ * <ul>
+ *   <li>Funcionário existe e está ativo</li>
+ *   <li>Consistência matemática: |valorTotal - valorParcela × numParcelas| ≤ 0.01</li>
+ * </ul>
+ *
+ * <p>A validação matemática é feita ANTES do banco para dar mensagem clara ao usuário,
+ * evitando que a {@code DataIntegrityViolationException} do CHECK constraint vaze para a API.
+ */
+@Service
+public class CadastrarAdiantamentoServiceImpl implements CadastrarAdiantamentoPortIn {
+
+    private static final BigDecimal TOLERANCIA = new BigDecimal("0.01");
+
+    private final FuncionarioRepositoryPortOut funcionarioRepository;
+    private final AdiantamentoRepositoryPortOut adiantamentoRepository;
+
+    public CadastrarAdiantamentoServiceImpl(
+            FuncionarioRepositoryPortOut funcionarioRepository,
+            AdiantamentoRepositoryPortOut adiantamentoRepository) {
+        this.funcionarioRepository = funcionarioRepository;
+        this.adiantamentoRepository = adiantamentoRepository;
+    }
+
+    @Override
+    public Adiantamento cadastrar(Long funcionarioId, Adiantamento adiantamento) {
+        // Validar funcionário ativo
+        funcionarioRepository.findAtivoById(funcionarioId)
+                .orElseThrow(() -> new FuncionarioNaoEncontradoException(
+                        "Funcionário não encontrado ou inativo: id=" + funcionarioId));
+
+        // Validar consistência matemática do plano
+        validarConsistenciaMatemática(adiantamento);
+
+        Adiantamento paraSalvar = Adiantamento.builder()
+                .funcionarioId(funcionarioId)
+                .descricao(adiantamento.getDescricao())
+                .valorTotal(adiantamento.getValorTotal())
+                .valorParcela(adiantamento.getValorParcela())
+                .numParcelas(adiantamento.getNumParcelas())
+                .parcelasPagas(0)
+                .dataInicio(adiantamento.getDataInicio())
+                .ativo(true)
+                .build();
+
+        return adiantamentoRepository.save(paraSalvar);
+    }
+
+    /**
+     * Valida que |valorTotal - valorParcela × numParcelas| ≤ 0.01.
+     *
+     * <p>Essa invariante é espelhada no banco como {@code chk_adiant_consistencia}.
+     * Validar aqui (application layer) garante mensagem de erro clara antes de chegar no banco.
+     */
+    static void validarConsistenciaMatemática(Adiantamento a) {
+        BigDecimal totalCalculado = a.getValorParcela().multiply(new BigDecimal(a.getNumParcelas()));
+        BigDecimal diferenca = a.getValorTotal().subtract(totalCalculado).abs();
+        if (diferenca.compareTo(TOLERANCIA) > 0) {
+            throw new IllegalArgumentException(
+                    "Plano inconsistente: |valorTotal (" + a.getValorTotal()
+                            + ") - valorParcela (" + a.getValorParcela()
+                            + ") × numParcelas (" + a.getNumParcelas()
+                            + ")| = " + diferenca + " > 0.01");
+        }
+    }
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/services/CancelarAdiantamentoServiceImpl.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/services/CancelarAdiantamentoServiceImpl.java
@@ -1,0 +1,41 @@
+package br.com.satyan.stering.saita.financasbottelegram.application.services;
+
+import br.com.satyan.stering.saita.financasbottelegram.application.port.in.CancelarAdiantamentoPortIn;
+import br.com.satyan.stering.saita.financasbottelegram.application.port.out.AdiantamentoRepositoryPortOut;
+import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Adiantamento;
+import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.AdiantamentoJaQuitadoException;
+import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.AdiantamentoNaoEncontradoException;
+import org.springframework.stereotype.Service;
+
+/**
+ * Implementação do use case de cancelamento de adiantamento.
+ *
+ * <p>Soft cancel: seta {@code ativo=false}. Não permite cancelar adiantamento já quitado
+ * ({@code parcelasPagas == numParcelas}).
+ */
+@Service
+public class CancelarAdiantamentoServiceImpl implements CancelarAdiantamentoPortIn {
+
+    private final AdiantamentoRepositoryPortOut repository;
+
+    public CancelarAdiantamentoServiceImpl(AdiantamentoRepositoryPortOut repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public void cancelar(Long adiantamentoId) {
+        Adiantamento adiantamento = repository.findById(adiantamentoId)
+                .orElseThrow(() -> new AdiantamentoNaoEncontradoException(adiantamentoId));
+
+        // Verificar se já está quitado
+        if (adiantamento.getParcelasPagas() != null
+                && adiantamento.getNumParcelas() != null
+                && adiantamento.getParcelasPagas().equals(adiantamento.getNumParcelas())) {
+            throw new AdiantamentoJaQuitadoException(adiantamentoId);
+        }
+
+        // Soft cancel
+        adiantamento.setAtivo(false);
+        repository.save(adiantamento);
+    }
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/domain/exceptions/AdiantamentoJaQuitadoException.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/domain/exceptions/AdiantamentoJaQuitadoException.java
@@ -1,0 +1,12 @@
+package br.com.satyan.stering.saita.financasbottelegram.domain.exceptions;
+
+/**
+ * Lançada ao tentar cancelar um adiantamento que já foi quitado
+ * ({@code parcelasPagas == numParcelas}).
+ */
+public class AdiantamentoJaQuitadoException extends RuntimeException {
+
+    public AdiantamentoJaQuitadoException(Long id) {
+        super("Adiantamento já quitado e não pode ser cancelado: id=" + id);
+    }
+}

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/domain/exceptions/AdiantamentoNaoEncontradoException.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/domain/exceptions/AdiantamentoNaoEncontradoException.java
@@ -1,0 +1,8 @@
+package br.com.satyan.stering.saita.financasbottelegram.domain.exceptions;
+
+public class AdiantamentoNaoEncontradoException extends RuntimeException {
+
+    public AdiantamentoNaoEncontradoException(Long id) {
+        super("Adiantamento não encontrado: id=" + id);
+    }
+}

--- a/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/application/services/CadastrarAdiantamentoServiceImplTest.java
+++ b/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/application/services/CadastrarAdiantamentoServiceImplTest.java
@@ -1,0 +1,186 @@
+package br.com.satyan.stering.saita.financasbottelegram.application.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import br.com.satyan.stering.saita.financasbottelegram.application.port.out.AdiantamentoRepositoryPortOut;
+import br.com.satyan.stering.saita.financasbottelegram.application.port.out.FuncionarioRepositoryPortOut;
+import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Adiantamento;
+import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Funcionario;
+import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.FuncionarioNaoEncontradoException;
+import br.com.satyan.stering.saita.financasbottelegram.domain.vo.FormaPagamento;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CadastrarAdiantamentoServiceImplTest {
+
+    @Mock
+    private FuncionarioRepositoryPortOut funcionarioRepository;
+
+    @Mock
+    private AdiantamentoRepositoryPortOut adiantamentoRepository;
+
+    private CadastrarAdiantamentoServiceImpl service;
+
+    private final Funcionario funcionarioAtivo = Funcionario.builder()
+            .id(1L)
+            .nome("Maria")
+            .salarioBase(new BigDecimal("1800.00"))
+            .formaPagamento(FormaPagamento.PIX)
+            .chavePix("maria@pix.com")
+            .ativo(true)
+            .build();
+
+    @BeforeEach
+    void setUp() {
+        service = new CadastrarAdiantamentoServiceImpl(funcionarioRepository, adiantamentoRepository);
+    }
+
+    // ── Testes de cadastro ─────────────────────────────────────────────────────
+
+    @Test
+    void deveCadastrarAdiantamentoComPlanoConsistente() {
+        when(funcionarioRepository.findAtivoById(1L)).thenReturn(Optional.of(funcionarioAtivo));
+
+        Adiantamento input = Adiantamento.builder()
+                .descricao("Adiantamento de férias")
+                .valorTotal(new BigDecimal("300.00"))
+                .valorParcela(new BigDecimal("100.00"))
+                .numParcelas(3)
+                .dataInicio(LocalDate.of(2026, 6, 1))
+                .build();
+
+        Adiantamento salvo = Adiantamento.builder()
+                .id(10L)
+                .funcionarioId(1L)
+                .descricao("Adiantamento de férias")
+                .valorTotal(new BigDecimal("300.00"))
+                .valorParcela(new BigDecimal("100.00"))
+                .numParcelas(3)
+                .parcelasPagas(0)
+                .dataInicio(LocalDate.of(2026, 6, 1))
+                .ativo(true)
+                .build();
+
+        when(adiantamentoRepository.save(any())).thenReturn(salvo);
+
+        Adiantamento resultado = service.cadastrar(1L, input);
+
+        assertThat(resultado.getId()).isEqualTo(10L);
+        assertThat(resultado.getAtivo()).isTrue();
+        assertThat(resultado.getParcelasPagas()).isEqualTo(0);
+    }
+
+    @Test
+    void deveSalvarAdiantamentoComCamposCorretos() {
+        when(funcionarioRepository.findAtivoById(1L)).thenReturn(Optional.of(funcionarioAtivo));
+
+        Adiantamento input = Adiantamento.builder()
+                .descricao("Empréstimo")
+                .valorTotal(new BigDecimal("200.00"))
+                .valorParcela(new BigDecimal("100.00"))
+                .numParcelas(2)
+                .dataInicio(LocalDate.of(2026, 7, 1))
+                .build();
+
+        when(adiantamentoRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.cadastrar(1L, input);
+
+        ArgumentCaptor<Adiantamento> captor = ArgumentCaptor.forClass(Adiantamento.class);
+        verify(adiantamentoRepository).save(captor.capture());
+
+        Adiantamento paraSalvar = captor.getValue();
+        assertThat(paraSalvar.getFuncionarioId()).isEqualTo(1L);
+        assertThat(paraSalvar.getAtivo()).isTrue();
+        assertThat(paraSalvar.getParcelasPagas()).isEqualTo(0);
+        assertThat(paraSalvar.getDescricao()).isEqualTo("Empréstimo");
+    }
+
+    @Test
+    void deveRejeitarPlanoInconsistente() {
+        when(funcionarioRepository.findAtivoById(1L)).thenReturn(Optional.of(funcionarioAtivo));
+
+        // valorTotal=300, valorParcela=100, numParcelas=4 → 100*4=400 ≠ 300 → diferença 100 > 0.01
+        Adiantamento input = Adiantamento.builder()
+                .descricao("Plano inconsistente")
+                .valorTotal(new BigDecimal("300.00"))
+                .valorParcela(new BigDecimal("100.00"))
+                .numParcelas(4)
+                .dataInicio(LocalDate.of(2026, 6, 1))
+                .build();
+
+        assertThatThrownBy(() -> service.cadastrar(1L, input))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("inconsistente");
+    }
+
+    @Test
+    void deveRejeitarFuncionarioInativo() {
+        when(funcionarioRepository.findAtivoById(99L)).thenReturn(Optional.empty());
+
+        Adiantamento input = Adiantamento.builder()
+                .descricao("Adiantamento")
+                .valorTotal(new BigDecimal("100.00"))
+                .valorParcela(new BigDecimal("100.00"))
+                .numParcelas(1)
+                .dataInicio(LocalDate.of(2026, 6, 1))
+                .build();
+
+        assertThatThrownBy(() -> service.cadastrar(99L, input))
+                .isInstanceOf(FuncionarioNaoEncontradoException.class);
+    }
+
+    // ── Testes de validarConsistenciaMatemática (método package-private) ──────
+
+    @Test
+    void deveAceitarPlanoDentroDaTolerancia() {
+        // 100.00 * 3 = 300.00; diferença = |300.00 - 300.00| = 0 ≤ 0.01
+        Adiantamento a = Adiantamento.builder()
+                .valorTotal(new BigDecimal("300.00"))
+                .valorParcela(new BigDecimal("100.00"))
+                .numParcelas(3)
+                .build();
+
+        // Não deve lançar exceção
+        CadastrarAdiantamentoServiceImpl.validarConsistenciaMatemática(a);
+    }
+
+    @Test
+    void deveAceitarPlanoDentroDaToleranciaComArredondamento() {
+        // 33.33 * 3 = 99.99; |100.00 - 99.99| = 0.01 == tolerância (<=, não <)
+        Adiantamento a = Adiantamento.builder()
+                .valorTotal(new BigDecimal("100.00"))
+                .valorParcela(new BigDecimal("33.33"))
+                .numParcelas(3)
+                .build();
+
+        // Diferença exata = 0.01, deve ser aceito
+        CadastrarAdiantamentoServiceImpl.validarConsistenciaMatemática(a);
+    }
+
+    @Test
+    void deveRejeitarPlanoComDiferencaAcimaDeTolerancia() {
+        // 100.01 * 3 = 300.03; |300.00 - 300.03| = 0.03 > 0.01
+        Adiantamento a = Adiantamento.builder()
+                .valorTotal(new BigDecimal("300.00"))
+                .valorParcela(new BigDecimal("100.01"))
+                .numParcelas(3)
+                .build();
+
+        assertThatThrownBy(() -> CadastrarAdiantamentoServiceImpl.validarConsistenciaMatemática(a))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("inconsistente");
+    }
+}

--- a/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/application/services/CancelarAdiantamentoServiceImplTest.java
+++ b/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/application/services/CancelarAdiantamentoServiceImplTest.java
@@ -1,0 +1,121 @@
+package br.com.satyan.stering.saita.financasbottelegram.application.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import br.com.satyan.stering.saita.financasbottelegram.application.port.out.AdiantamentoRepositoryPortOut;
+import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Adiantamento;
+import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.AdiantamentoJaQuitadoException;
+import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.AdiantamentoNaoEncontradoException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CancelarAdiantamentoServiceImplTest {
+
+    @Mock
+    private AdiantamentoRepositoryPortOut repository;
+
+    private CancelarAdiantamentoServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new CancelarAdiantamentoServiceImpl(repository);
+    }
+
+    @Test
+    void deveCancelarAdiantamentoAtivo() {
+        Adiantamento adiantamentoAtivo = Adiantamento.builder()
+                .id(1L)
+                .funcionarioId(1L)
+                .descricao("Adiantamento")
+                .valorTotal(new BigDecimal("300.00"))
+                .valorParcela(new BigDecimal("100.00"))
+                .numParcelas(3)
+                .parcelasPagas(1)  // 1 de 3 — ainda não quitado
+                .dataInicio(LocalDate.of(2026, 6, 1))
+                .ativo(true)
+                .build();
+
+        when(repository.findById(1L)).thenReturn(Optional.of(adiantamentoAtivo));
+        when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.cancelar(1L);
+
+        ArgumentCaptor<Adiantamento> captor = ArgumentCaptor.forClass(Adiantamento.class);
+        verify(repository).save(captor.capture());
+        assertThat(captor.getValue().getAtivo()).isFalse();
+    }
+
+    @Test
+    void deveCancelarAdiantamentoSemParcelasPagas() {
+        Adiantamento adiantamentoNovo = Adiantamento.builder()
+                .id(2L)
+                .numParcelas(2)
+                .parcelasPagas(0)  // nunca descontado
+                .ativo(true)
+                .build();
+
+        when(repository.findById(2L)).thenReturn(Optional.of(adiantamentoNovo));
+        when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        assertThatCode(() -> service.cancelar(2L)).doesNotThrowAnyException();
+        verify(repository).save(any());
+    }
+
+    @Test
+    void deveRejeitarCancelamentoDeAdiantamentoJaQuitado() {
+        Adiantamento adiantamentoQuitado = Adiantamento.builder()
+                .id(3L)
+                .numParcelas(3)
+                .parcelasPagas(3)  // igual a numParcelas — já quitado
+                .ativo(true)
+                .build();
+
+        when(repository.findById(3L)).thenReturn(Optional.of(adiantamentoQuitado));
+
+        assertThatThrownBy(() -> service.cancelar(3L))
+                .isInstanceOf(AdiantamentoJaQuitadoException.class);
+
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void deveRejeitarCancelamentoDeAdiantamentoNaoEncontrado() {
+        when(repository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.cancelar(99L))
+                .isInstanceOf(AdiantamentoNaoEncontradoException.class);
+
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void deveCancelarAdiantamentoComParcelasPagasNulas() {
+        // parcelasPagas = null — não deve lançar NullPointerException, deve cancelar
+        Adiantamento adiantamentoSemParcelas = Adiantamento.builder()
+                .id(4L)
+                .numParcelas(3)
+                .parcelasPagas(null)
+                .ativo(true)
+                .build();
+
+        when(repository.findById(4L)).thenReturn(Optional.of(adiantamentoSemParcelas));
+        when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        assertThatCode(() -> service.cancelar(4L)).doesNotThrowAnyException();
+        verify(repository).save(any());
+    }
+}


### PR DESCRIPTION
## Summary

- Use case `CadastrarAdiantamentoServiceImpl`: valida funcionário ativo + consistência matemática `|valorTotal - valorParcela × numParcelas| ≤ 0.01` antes de qualquer acesso ao banco (evita `DataIntegrityViolationException` opaca do CHECK constraint)
- Use case `CancelarAdiantamentoServiceImpl`: soft cancel (`ativo=false`); lança `AdiantamentoJaQuitadoException` (409) se `parcelasPagas == numParcelas`
- 3 endpoints em `FolhaController`: `POST /{id}/adiantamentos` (201), `GET /{id}/adiantamentos` (ativos), `DELETE /adiantamentos/{id}` (204)
- `RestExceptionHandler` com handlers 404 (`AdiantamentoNaoEncontradoException`) e 409 (`AdiantamentoJaQuitadoException`)
- 12 novos testes (332 total, 0 falhas)

## Test plan

- [x] `mvn test` verde — 332 testes, 0 falhas
- [x] `CadastrarAdiantamentoServiceImplTest`: plano consistente OK, plano inconsistente (400), tolerância de arredondamento (0.01 exato), funcionário inativo (404)
- [x] `CancelarAdiantamentoServiceImplTest`: cancelar ativo OK, cancelar quitado (409), não encontrado (404), parcelasPagas null (null-safe)
- [x] Branch convencao: `feature/be-027-cadastrar-adiantamento` ✓
- [x] Território: só `financas_bot_telegram/` e `docs/sprints/03-folha-pagamento/status/` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)