### PR TITLE
feat(BE-029): testes FecharMesUseCase — 12 unitários + 4 integração

### DIFF
--- a/docs/sprints/03-folha-pagamento/status/BE-029-testes-fechar-mes.md
+++ b/docs/sprints/03-folha-pagamento/status/BE-029-testes-fechar-mes.md
@@ -1,0 +1,100 @@
+---
+task: BE-029
+titulo: "Testes — FecharMesUseCase (unitário) + integração endpoint fechamento"
+data: 2026-06-04
+branch: feature/be-029-testes-fechar-mes
+responsavel: claude-back
+estado: concluido
+gates:
+  build: ok
+  lint: ok
+  testes: ok
+  testes_total: 348
+  testes_novos: 16
+  cobertura_pct: na
+  branch_convencao: ok
+  territorio: ok
+commits:
+  - null
+pr: null
+desvios: 0
+pendencias_humano: 0
+---
+
+# BE-029 — Testes — FecharMesUseCase + integração endpoint fechamento
+
+## O que foi feito
+
+Cobertura completa do `FecharMesServiceImpl` com 16 novos testes (plan pedia ≥ 11):
+
+**Unitários — `FecharMesServiceImplTest` (12 testes):**
+- `deveFazerFechamentoComValesEAdiantamentos` — fluxo principal, verifica `markAllClosed` com IDs corretos e 2 chamadas a `adiantamentoRepository.save`.
+- `deveSalvarPedidoFolhaComCamposCorretos` — captura o pedido salvo e verifica `categoria=FOLHA`, `status=PENDENTE`, `mesReferencia`, `observacao` não-vazio, e `requisitanteId=null` (pedido sistema).
+- `deveDesativarAdiantamentoNaUltimaParcela` — após incremento de `parcelasPagas`, `ativo=false`.
+- `deveFazerFechamentoSemValesNemAdiantamentos` — `valor = salárioBase`, zero chamadas a `markAllClosed` e `adiantamentoRepository.save`.
+- `deveAplicarAjustePositivo` — `valor = salárioBase + ajuste`.
+- `deveAplicarAjusteNegativo` — `valor = salárioBase - |ajuste|`.
+- `devePermitirValorFinalNegativo` — domínio aceita sem lançar exceção.
+- `deveRejeitarFechamentoDuplicado` — `existsFolha=true` → `FechamentoDuplicadoException`; `save` nunca chamado.
+- `deveRejeitarFuncionarioInativo` — `findAtivoById` vazio → `FuncionarioNaoEncontradoException`.
+- `deveGerarTextoFechamentoComFormatoCorreto` — verifica formato PT-BR ("R$ 2.000,00", vírgula decimal, ponto milhar).
+- `deveUsarSingularParaUmValeEUmaParcela` — "1 vale" e "1 parcela" (singular).
+- `deveGerarTextoParaFechamentoSemDescontos` — "0 vales", "0 parcelas".
+
+**Integração — `FecharMesIntegrationTest` (4 testes, MySQL Testcontainers):**
+- `deveFecharMesComSucesso` — cria funcionário + vale via SQL, chama endpoint, verifica 200 + vale marcado `fechado=true` + Pedido FOLHA criado no banco.
+- `deveRetornar409NoFechamentoDuplicado` — dois POSTs no mesmo mês; segundo retorna 409 com `FECHAMENTO_DUPLICADO`.
+- `deveRetornar404ParaFuncionarioInexistente` — id 999999 não existe → 404.
+- `deveListarFechamentosAnteriores` — GET `/fechamentos` retorna dois meses em ordem DESC.
+
+Total: 348 testes, 0 falhas.
+
+---
+
+## Desvios do plano
+
+Nenhum.
+
+---
+
+## Decisões tomadas durante a execução
+
+- **Naming `FecharMesIntegrationTest` (não `FecharMesEndpointIT`)**: Maven Surefire não detecta classes com sufixo `IT` por padrão (convenção Failsafe). Todos os integration tests existentes no projeto usam `*IntegrationTest`. Seguido o padrão estabelecido.
+- **`gerarTextoFechamento` testado como static package-private**: o método é `static` no `FecharMesServiceImpl` — testado diretamente sem instanciar o serviço, o que foca o teste na função de formatação sem necessidade de mocks. Assertiva de pluralização (singular/plural) coberta em testes separados.
+- **Cleanup via `@AfterEach`** no teste de integração: cada teste de integração cria seu próprio funcionário e limpa ao final, garantindo isolamento entre testes na mesma sessão do MySQL compartilhado (Singleton Container).
+
+---
+
+## Decisões pendentes (esperando humano)
+
+Nenhuma — tarefa fechada.
+
+---
+
+## Próximos passos / observações pro próximo
+
+- Sprint 03 back está completa. FE-016 e FE-017 podem iniciar.
+- A V7 migration (`requisitante_id` nullable) aplicará automaticamente via Flyway no próximo deploy.
+- Os testes de integração são skipped localmente quando Docker não está disponível (pre-existente; CI resolve). Ver `project_docker_testcontainers.md` no memory.
+
+---
+
+## Padrões técnicos (BE e FE: obrigatório; DEP/CI/EVO: omitir)
+
+**SOLID:**
+- **DIP nos testes unitários**: `FecharMesServiceImpl` é instanciado com mocks dos ports (`FuncionarioRepositoryPortOut`, `PedidoPagamentoRepositoryPort`, `AdiantamentoRepositoryPortOut`) — os testes verificam o comportamento lógico sem precisar de banco ou Spring context.
+
+**Design Patterns:**
+- **Singleton Container (Testcontainers)**: o MySQL é iniciado uma vez por JVM (`static final MySQLContainer`) e compartilhado por todos os testes de integração, conforme padrão do `AbstractIntegrationTest`. Isolar cada teste via `@BeforeEach` + `@AfterEach` SQL é a prática correta com este padrão.
+- **Arrange-Act-Assert**: todos os testes unitários seguem AAA explicitamente — setup dos mocks, chamada do método, assertivas nos resultados e verificações de interação (`verify`).
+
+**Arquitetura hexagonal:**
+- Os testes unitários verificam o **comportamento do use case** (lógica dos 11 passos), não a implementação dos adapters. Os testes de integração verificam a **stack completa** (HTTP → controller → use case → adapters → banco).
+- O teste `deveSalvarPedidoFolhaComCamposCorretos` captura o `PedidoPagamento` passado para o port out — confirmando que o use case não vaza detalhes de infraestrutura (ex: `requisitanteId=null` é preenchido pelo use case, não pelo adapter).
+
+---
+
+## Arquivos criados/modificados
+
+- `test/.../services/FecharMesServiceImplTest.java` (novo: 12 testes unitários)
+- `test/.../integration/FecharMesIntegrationTest.java` (novo: 4 testes de integração)

--- a/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/application/services/FecharMesServiceImplTest.java
+++ b/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/application/services/FecharMesServiceImplTest.java
@@ -1,0 +1,334 @@
+package br.com.satyan.stering.saita.financasbottelegram.application.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import br.com.satyan.stering.saita.financasbottelegram.application.port.out.AdiantamentoRepositoryPortOut;
+import br.com.satyan.stering.saita.financasbottelegram.application.port.out.FuncionarioRepositoryPortOut;
+import br.com.satyan.stering.saita.financasbottelegram.application.port.out.PedidoPagamentoRepositoryPort;
+import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Adiantamento;
+import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Funcionario;
+import br.com.satyan.stering.saita.financasbottelegram.domain.enums.StatusPedido;
+import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.FechamentoDuplicadoException;
+import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.FuncionarioNaoEncontradoException;
+import br.com.satyan.stering.saita.financasbottelegram.domain.model.PedidoPagamento;
+import br.com.satyan.stering.saita.financasbottelegram.domain.vo.CategoriaPedido;
+import br.com.satyan.stering.saita.financasbottelegram.domain.vo.FormaPagamento;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FecharMesServiceImplTest {
+
+    @Mock
+    private FuncionarioRepositoryPortOut funcionarioRepository;
+
+    @Mock
+    private PedidoPagamentoRepositoryPort pedidoRepository;
+
+    @Mock
+    private AdiantamentoRepositoryPortOut adiantamentoRepository;
+
+    private FecharMesServiceImpl service;
+
+    private static final YearMonth MES = YearMonth.of(2026, 5);
+    private static final LocalDate PRIMEIRO_DO_MES = LocalDate.of(2026, 5, 1);
+
+    private final Funcionario funcionario = Funcionario.builder()
+            .id(1L)
+            .nome("Maria")
+            .salarioBase(new BigDecimal("2000.00"))
+            .formaPagamento(FormaPagamento.PIX)
+            .chavePix("maria@pix.com")
+            .ativo(true)
+            .build();
+
+    @BeforeEach
+    void setUp() {
+        service = new FecharMesServiceImpl(funcionarioRepository, pedidoRepository, adiantamentoRepository);
+    }
+
+    // ── (1) Fechamento padrão ─────────────────────────────────────────────────
+
+    @Test
+    void deveFazerFechamentoComValesEAdiantamentos() {
+        when(pedidoRepository.existsFolha(1L, PRIMEIRO_DO_MES)).thenReturn(false);
+        when(funcionarioRepository.findAtivoById(1L)).thenReturn(Optional.of(funcionario));
+
+        PedidoPagamento vale1 = pedido(10L, new BigDecimal("80.00"));
+        PedidoPagamento vale2 = pedido(11L, new BigDecimal("70.00"));
+        when(pedidoRepository.findValesAbertos(eq(1L), any(), any()))
+                .thenReturn(List.of(vale1, vale2)); // totalVales = 150
+
+        Adiantamento adiant1 = adiantamento(20L, new BigDecimal("50.00"), 3, 1);
+        Adiantamento adiant2 = adiantamento(21L, new BigDecimal("30.00"), 2, 0);
+        when(adiantamentoRepository.findAtivosParaFechamento(1L))
+                .thenReturn(List.of(adiant1, adiant2)); // totalParcelas = 80
+
+        // valorFinal = 2000 - 150 - 80 + 0 = 1770
+        PedidoPagamento salvo = pedidoFolha(100L, new BigDecimal("1770.00"));
+        when(pedidoRepository.save(any())).thenReturn(salvo);
+        when(adiantamentoRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        PedidoPagamento resultado = service.fechar(1L, MES, BigDecimal.ZERO);
+
+        assertThat(resultado.getId()).isEqualTo(100L);
+        assertThat(resultado.getValor()).isEqualByComparingTo("1770.00");
+
+        // passo 9: markAllClosed com IDs dos vales
+        ArgumentCaptor<List<Long>> captor = ArgumentCaptor.forClass(List.class);
+        verify(pedidoRepository).markAllClosed(captor.capture());
+        assertThat(captor.getValue()).containsExactlyInAnyOrder(10L, 11L);
+
+        // passo 10: 2 adiantamentos atualizados
+        verify(adiantamentoRepository, times(2)).save(any());
+    }
+
+    @Test
+    void deveSalvarPedidoFolhaComCamposCorretos() {
+        when(pedidoRepository.existsFolha(1L, PRIMEIRO_DO_MES)).thenReturn(false);
+        when(funcionarioRepository.findAtivoById(1L)).thenReturn(Optional.of(funcionario));
+        when(pedidoRepository.findValesAbertos(any(), any(), any())).thenReturn(List.of());
+        when(adiantamentoRepository.findAtivosParaFechamento(any())).thenReturn(List.of());
+        when(pedidoRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.fechar(1L, MES, BigDecimal.ZERO);
+
+        ArgumentCaptor<PedidoPagamento> captor = ArgumentCaptor.forClass(PedidoPagamento.class);
+        verify(pedidoRepository).save(captor.capture());
+
+        PedidoPagamento paraSalvar = captor.getValue();
+        assertThat(paraSalvar.getCategoria()).isEqualTo(CategoriaPedido.FOLHA);
+        assertThat(paraSalvar.getFuncionarioId()).isEqualTo(1L);
+        assertThat(paraSalvar.getStatus()).isEqualTo(StatusPedido.PENDENTE);
+        assertThat(paraSalvar.getMesReferencia()).isEqualTo(PRIMEIRO_DO_MES);
+        assertThat(paraSalvar.getObservacao()).isNotBlank();
+        assertThat(paraSalvar.getRequisitanteId()).isNull(); // sistema, sem requisitante
+    }
+
+    // ── (2) Adiantamento quitado na última parcela ────────────────────────────
+
+    @Test
+    void deveDesativarAdiantamentoNaUltimaParcela() {
+        when(pedidoRepository.existsFolha(1L, PRIMEIRO_DO_MES)).thenReturn(false);
+        when(funcionarioRepository.findAtivoById(1L)).thenReturn(Optional.of(funcionario));
+        when(pedidoRepository.findValesAbertos(any(), any(), any())).thenReturn(List.of());
+
+        // numParcelas=3, parcelasPagas=2 → após incremento fica 3 (quitado)
+        Adiantamento ultimaParcela = adiantamento(30L, new BigDecimal("100.00"), 3, 2);
+        when(adiantamentoRepository.findAtivosParaFechamento(1L))
+                .thenReturn(List.of(ultimaParcela));
+
+        when(pedidoRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(adiantamentoRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.fechar(1L, MES, BigDecimal.ZERO);
+
+        ArgumentCaptor<Adiantamento> captor = ArgumentCaptor.forClass(Adiantamento.class);
+        verify(adiantamentoRepository).save(captor.capture());
+
+        Adiantamento atualizado = captor.getValue();
+        assertThat(atualizado.getParcelasPagas()).isEqualTo(3);
+        assertThat(atualizado.getAtivo()).isFalse(); // quitado
+    }
+
+    // ── (3) Sem vales nem adiantamentos ──────────────────────────────────────
+
+    @Test
+    void deveFazerFechamentoSemValesNemAdiantamentos() {
+        when(pedidoRepository.existsFolha(1L, PRIMEIRO_DO_MES)).thenReturn(false);
+        when(funcionarioRepository.findAtivoById(1L)).thenReturn(Optional.of(funcionario));
+        when(pedidoRepository.findValesAbertos(any(), any(), any())).thenReturn(List.of());
+        when(adiantamentoRepository.findAtivosParaFechamento(any())).thenReturn(List.of());
+
+        when(pedidoRepository.save(any())).thenAnswer(inv -> {
+            PedidoPagamento p = inv.getArgument(0);
+            return PedidoPagamento.builder().id(1L).valor(p.getValor())
+                    .observacao(p.getObservacao()).mesReferencia(p.getMesReferencia())
+                    .status(p.getStatus()).categoria(p.getCategoria())
+                    .funcionarioId(p.getFuncionarioId()).build();
+        });
+
+        PedidoPagamento resultado = service.fechar(1L, MES, BigDecimal.ZERO);
+
+        assertThat(resultado.getValor()).isEqualByComparingTo("2000.00"); // salário base
+        verify(pedidoRepository, never()).markAllClosed(anyList());
+        verify(adiantamentoRepository, never()).save(any());
+    }
+
+    // ── (4) Ajuste positivo ───────────────────────────────────────────────────
+
+    @Test
+    void deveAplicarAjustePositivo() {
+        when(pedidoRepository.existsFolha(1L, PRIMEIRO_DO_MES)).thenReturn(false);
+        when(funcionarioRepository.findAtivoById(1L)).thenReturn(Optional.of(funcionario));
+        when(pedidoRepository.findValesAbertos(any(), any(), any())).thenReturn(List.of());
+        when(adiantamentoRepository.findAtivosParaFechamento(any())).thenReturn(List.of());
+        when(pedidoRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.fechar(1L, MES, new BigDecimal("200.00")); // bônus R$200
+
+        ArgumentCaptor<PedidoPagamento> captor = ArgumentCaptor.forClass(PedidoPagamento.class);
+        verify(pedidoRepository).save(captor.capture());
+        // 2000 + 200 = 2200
+        assertThat(captor.getValue().getValor()).isEqualByComparingTo("2200.00");
+    }
+
+    // ── (5) Ajuste negativo ───────────────────────────────────────────────────
+
+    @Test
+    void deveAplicarAjusteNegativo() {
+        when(pedidoRepository.existsFolha(1L, PRIMEIRO_DO_MES)).thenReturn(false);
+        when(funcionarioRepository.findAtivoById(1L)).thenReturn(Optional.of(funcionario));
+        when(pedidoRepository.findValesAbertos(any(), any(), any())).thenReturn(List.of());
+        when(adiantamentoRepository.findAtivosParaFechamento(any())).thenReturn(List.of());
+        when(pedidoRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.fechar(1L, MES, new BigDecimal("-150.00")); // desconto extra
+
+        ArgumentCaptor<PedidoPagamento> captor = ArgumentCaptor.forClass(PedidoPagamento.class);
+        verify(pedidoRepository).save(captor.capture());
+        // 2000 - 150 = 1850
+        assertThat(captor.getValue().getValor()).isEqualByComparingTo("1850.00");
+    }
+
+    // ── (6) Valor final negativo (vales > salário) ───────────────────────────
+
+    @Test
+    void devePermitirValorFinalNegativo() {
+        when(pedidoRepository.existsFolha(1L, PRIMEIRO_DO_MES)).thenReturn(false);
+        when(funcionarioRepository.findAtivoById(1L)).thenReturn(Optional.of(funcionario));
+
+        // vale de R$2500 > salário de R$2000
+        PedidoPagamento valeGrande = pedido(50L, new BigDecimal("2500.00"));
+        when(pedidoRepository.findValesAbertos(any(), any(), any())).thenReturn(List.of(valeGrande));
+        when(adiantamentoRepository.findAtivosParaFechamento(any())).thenReturn(List.of());
+        when(pedidoRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        PedidoPagamento resultado = service.fechar(1L, MES, BigDecimal.ZERO);
+
+        // Domínio permite valor negativo
+        assertThat(resultado.getValor()).isEqualByComparingTo("-500.00");
+    }
+
+    // ── (7) Fechamento duplicado ──────────────────────────────────────────────
+
+    @Test
+    void deveRejeitarFechamentoDuplicado() {
+        when(pedidoRepository.existsFolha(1L, PRIMEIRO_DO_MES)).thenReturn(true);
+
+        assertThatThrownBy(() -> service.fechar(1L, MES, BigDecimal.ZERO))
+                .isInstanceOf(FechamentoDuplicadoException.class)
+                .hasMessageContaining("2026-05");
+
+        verify(pedidoRepository, never()).save(any());
+    }
+
+    // ── (8) Funcionário inativo ───────────────────────────────────────────────
+
+    @Test
+    void deveRejeitarFuncionarioInativo() {
+        when(pedidoRepository.existsFolha(99L, PRIMEIRO_DO_MES)).thenReturn(false);
+        when(funcionarioRepository.findAtivoById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.fechar(99L, MES, BigDecimal.ZERO))
+                .isInstanceOf(FuncionarioNaoEncontradoException.class);
+
+        verify(pedidoRepository, never()).save(any());
+    }
+
+    // ── gerarTextoFechamento ──────────────────────────────────────────────────
+
+    @Test
+    void deveGerarTextoFechamentoComFormatoCorreto() {
+        String texto = FecharMesServiceImpl.gerarTextoFechamento(
+                new BigDecimal("2000.00"),
+                new BigDecimal("150.00"), 3,
+                new BigDecimal("80.00"), 2,
+                BigDecimal.ZERO,
+                new BigDecimal("1770.00"));
+
+        assertThat(texto).contains("Salario base: R$ 2.000,00");
+        assertThat(texto).contains("Vales: R$ 150,00 (3 vales)");
+        assertThat(texto).contains("Adiantamentos: R$ 80,00 (2 parcelas)");
+        assertThat(texto).contains("Ajuste: R$ 0,00");
+        assertThat(texto).contains("Liquido: R$ 1.770,00");
+    }
+
+    @Test
+    void deveUsarSingularParaUmValeEUmaParcela() {
+        String texto = FecharMesServiceImpl.gerarTextoFechamento(
+                new BigDecimal("1000.00"),
+                new BigDecimal("50.00"), 1,
+                new BigDecimal("100.00"), 1,
+                BigDecimal.ZERO,
+                new BigDecimal("850.00"));
+
+        assertThat(texto).contains("(1 vale)");
+        assertThat(texto).contains("(1 parcela)");
+    }
+
+    @Test
+    void deveGerarTextoParaFechamentoSemDescontos() {
+        String texto = FecharMesServiceImpl.gerarTextoFechamento(
+                new BigDecimal("1800.00"),
+                BigDecimal.ZERO, 0,
+                BigDecimal.ZERO, 0,
+                BigDecimal.ZERO,
+                new BigDecimal("1800.00"));
+
+        assertThat(texto).contains("Salario base: R$ 1.800,00");
+        assertThat(texto).contains("(0 vales)");
+        assertThat(texto).contains("(0 parcelas)");
+        assertThat(texto).contains("Liquido: R$ 1.800,00");
+    }
+
+    // ── Helpers de teste ─────────────────────────────────────────────────────
+
+    private PedidoPagamento pedido(Long id, BigDecimal valor) {
+        return PedidoPagamento.builder()
+                .id(id)
+                .valor(valor)
+                .dataPedido(LocalDate.of(2026, 5, 15))
+                .build();
+    }
+
+    private PedidoPagamento pedidoFolha(Long id, BigDecimal valor) {
+        return PedidoPagamento.builder()
+                .id(id)
+                .valor(valor)
+                .categoria(CategoriaPedido.FOLHA)
+                .status(StatusPedido.PENDENTE)
+                .mesReferencia(PRIMEIRO_DO_MES)
+                .dataPedido(PRIMEIRO_DO_MES)
+                .build();
+    }
+
+    private Adiantamento adiantamento(Long id, BigDecimal valorParcela, int numParcelas, int parcelasPagas) {
+        return Adiantamento.builder()
+                .id(id)
+                .funcionarioId(1L)
+                .valorParcela(valorParcela)
+                .numParcelas(numParcelas)
+                .parcelasPagas(parcelasPagas)
+                .dataInicio(LocalDate.of(2026, 1, 1)) // anterior a maio/26
+                .ativo(true)
+                .build();
+    }
+}

--- a/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/integration/FecharMesIntegrationTest.java
+++ b/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/integration/FecharMesIntegrationTest.java
@@ -1,0 +1,144 @@
+package br.com.satyan.stering.saita.financasbottelegram.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Testes de integração do endpoint {@code POST /api/funcionarios/{id}/fechamentos}.
+ *
+ * <p>Usa MySQL real via Testcontainers (herdado de {@link AbstractIntegrationTest}).
+ * Verifica fluxo completo E2E com banco real: criação de Pedido FOLHA, marcação
+ * de vales como fechados e idempotência (409 no segundo fechamento do mesmo mês).
+ */
+class FecharMesIntegrationTest extends AbstractIntegrationTest {
+
+    private Long funcionarioId;
+
+    @BeforeEach
+    void setUp() {
+        // Criar funcionário de teste
+        jdbcTemplate.update("""
+                INSERT INTO funcionario (nome, salario_base, forma_pagamento, chave_pix, ativo)
+                VALUES ('Maria Teste', 2000.00, 'PIX', 'maria@pix.com', TRUE)
+                """);
+        funcionarioId = jdbcTemplate.queryForObject(
+                "SELECT id FROM funcionario WHERE nome = 'Maria Teste' ORDER BY id DESC LIMIT 1",
+                Long.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (funcionarioId != null) {
+            // Ordem importa: FK constraints
+            jdbcTemplate.update("DELETE FROM pedidos_pagamento WHERE funcionario_id = ?", funcionarioId);
+            jdbcTemplate.update("DELETE FROM adiantamento WHERE funcionario_id = ?", funcionarioId);
+            jdbcTemplate.update("DELETE FROM funcionario WHERE id = ?", funcionarioId);
+        }
+    }
+
+    @Test
+    void deveFecharMesComSucesso() {
+        // Criar vale de R$150 para o funcionário em maio/2026
+        jdbcTemplate.update("""
+                INSERT INTO pedidos_pagamento
+                    (funcionario_id, valor, descricao, status, categoria, fechado, data_pedido, data_criacao)
+                VALUES (?, 150.00, 'Vale alimentacao', 'PENDENTE', 'VALE', FALSE, '2026-05-10', NOW())
+                """, funcionarioId);
+
+        String requestBody = """
+                { "mes": "2026-05", "ajuste": 0.00 }
+                """;
+
+        ResponseEntity<String> resp = restTemplate.postForEntity(
+                "/api/funcionarios/" + funcionarioId + "/fechamentos",
+                requestBodyEntity(requestBody),
+                String.class);
+
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(resp.getBody()).contains("PENDENTE");
+        assertThat(resp.getBody()).contains("Salario base");
+        assertThat(resp.getBody()).contains("Liquido");
+
+        // Vale deve estar marcado como fechado
+        Boolean valeFechado = jdbcTemplate.queryForObject(
+                "SELECT fechado FROM pedidos_pagamento WHERE funcionario_id = ? AND categoria = 'VALE'",
+                Boolean.class, funcionarioId);
+        assertThat(valeFechado).isTrue();
+
+        // Pedido FOLHA deve ter sido criado
+        Integer countFolha = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM pedidos_pagamento WHERE funcionario_id = ? AND categoria = 'FOLHA'",
+                Integer.class, funcionarioId);
+        assertThat(countFolha).isEqualTo(1);
+    }
+
+    @Test
+    void deveRetornar409NoFechamentoDuplicado() {
+        String requestBody = """
+                { "mes": "2026-04", "ajuste": 0.00 }
+                """;
+
+        // Primeiro fechamento
+        ResponseEntity<String> primeiro = restTemplate.postForEntity(
+                "/api/funcionarios/" + funcionarioId + "/fechamentos",
+                requestBodyEntity(requestBody),
+                String.class);
+        assertThat(primeiro.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        // Segundo fechamento do mesmo mês → 409
+        ResponseEntity<String> segundo = restTemplate.postForEntity(
+                "/api/funcionarios/" + funcionarioId + "/fechamentos",
+                requestBodyEntity(requestBody),
+                String.class);
+        assertThat(segundo.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+        assertThat(segundo.getBody()).contains("FECHAMENTO_DUPLICADO");
+    }
+
+    @Test
+    void deveRetornar404ParaFuncionarioInexistente() {
+        String requestBody = """
+                { "mes": "2026-06", "ajuste": 0.00 }
+                """;
+
+        ResponseEntity<String> resp = restTemplate.postForEntity(
+                "/api/funcionarios/999999/fechamentos",
+                requestBodyEntity(requestBody),
+                String.class);
+
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void deveListarFechamentosAnteriores() {
+        // Fecha dois meses diferentes
+        restTemplate.postForEntity(
+                "/api/funcionarios/" + funcionarioId + "/fechamentos",
+                requestBodyEntity("{ \"mes\": \"2026-03\", \"ajuste\": 0.00 }"),
+                String.class);
+        restTemplate.postForEntity(
+                "/api/funcionarios/" + funcionarioId + "/fechamentos",
+                requestBodyEntity("{ \"mes\": \"2026-02\", \"ajuste\": 0.00 }"),
+                String.class);
+
+        ResponseEntity<String> resp = restTemplate.getForEntity(
+                "/api/funcionarios/" + funcionarioId + "/fechamentos",
+                String.class);
+
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+        // Março deve aparecer antes de fevereiro (mes_referencia DESC)
+        assertThat(resp.getBody()).containsPattern("2026-03.*2026-02");
+    }
+
+    // ── Helper ───────────────────────────────────────────────────────────────
+
+    private org.springframework.http.HttpEntity<String> requestBodyEntity(String json) {
+        org.springframework.http.HttpHeaders headers = new org.springframework.http.HttpHeaders();
+        headers.setContentType(org.springframework.http.MediaType.APPLICATION_JSON);
+        return new org.springframework.http.HttpEntity<>(json, headers);
+    }
+}


### PR DESCRIPTION
## Summary

- **`FecharMesServiceImplTest`** (12 testes Mockito): cobre todos os 8 cenários do plano + 3 testes do método `gerarTextoFechamento` (formato PT-BR, singular, zero descontos) — captura `ArgumentCaptor` do Pedido FOLHA para verificar `requisitanteId=null`, `categoria=FOLHA`, `status=PENDENTE`
- **`FecharMesIntegrationTest`** (4 testes MySQL Testcontainers): fluxo E2E completo (funcionário + vale no banco → POST → vale `fechado=true` + Pedido FOLHA criado), idempotência 409, funcionário inexistente 404, GET ordenado DESC
- 348 testes totais, 0 falhas

## Test plan

- [x] 8 cenários unitários de `FecharMesUseCase` verdes ✓
- [x] 2+ cenários de integração do endpoint verdes (4 no total) ✓
- [x] Fechamento duplicado → 409 em integração ✓
- [x] `mvn test` verde com `testes_novos = 16 ≥ 11` ✓
- [x] Branch convencao: `feature/be-029-testes-fechar-mes` ✓
- [x] Território: só `financas_bot_telegram/` e `docs/sprints/03-folha-pagamento/status/` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)