### PR TITLE
feat(FE-016): tela folha funcionario — vales, adiantamentos, fechamentos

### DIFF
--- a/docs/sprints/03-folha-pagamento/status/FE-016-tela-folha-funcionario.md
+++ b/docs/sprints/03-folha-pagamento/status/FE-016-tela-folha-funcionario.md
@@ -1,0 +1,104 @@
+---
+task: FE-016
+titulo: "Tela Folha do Funcionário — vales, adiantamentos, fechamentos"
+data: 2026-06-04
+branch: feature/fe-016-tela-folha-funcionario
+responsavel: claude-front
+estado: concluido
+gates:
+  build: ok
+  lint: ok
+  testes: ok
+  testes_total: 78
+  testes_novos: 8
+  cobertura_pct: na
+  branch_convencao: ok
+  territorio: ok
+commits:
+  - placeholder
+pr: null
+desvios: 1
+pendencias_humano: 0
+---
+
+# FE-016 — Tela Folha do Funcionário — vales, adiantamentos, fechamentos
+
+## O que foi feito
+
+Implementada a tela `/folha/funcionarios/:id` substituindo o stub criado em FE-015. A tela agrega três seções independentes (vales, adiantamentos, fechamentos) alimentadas por quatro queries TanStack Query via `useFolhaFuncionario` hook.
+
+**Novos arquivos:**
+- `src/types/folha.ts` — estendido com `Vale`, `ValeRequest`, `Adiantamento`, `AdiantamentoRequest`, `Fechamento`
+- `src/api/folha.ts` — estendido com `listarVales`, `criarVale`, `listarAdiantamentos`, `criarAdiantamento`, `cancelarAdiantamento`, `listarFechamentos`
+- `src/hooks/folha/useFolhaFuncionario.ts` — hook agregador com 4 queries + 3 mutations + `invalidarPosFechamento()`
+- `src/components/folha/ValeForm.tsx` — form inline de vale (controlled state)
+- `src/components/folha/AdiantamentoForm.tsx` — form inline de adiantamento com `valorTotal` computado
+- `src/components/folha/ValesSection.tsx` — seção com seletor de mês (6 meses) + lista + ValeForm
+- `src/components/folha/AdiantamentosSection.tsx` — seção de adiantamentos com `parcela X/N` + cancelar
+- `src/components/folha/FechamentosSection.tsx` — accordion de fechamentos com expand de `observacao`
+- `src/components/folha/ModalFechamento.tsx` — stub com props interface exata para FE-017
+- `src/components/folha/FolhaFuncionario.test.tsx` — 8 testes novos
+- `src/paginas/folha/FolhaFuncionarioPage.tsx` — substituiu stub pela implementação completa
+
+---
+
+## Desvios do plano
+
+**1 desvio:** Props das seções `ValesSection` e `AdiantamentosSection` usam `Promise<unknown>` em vez de `Promise<void>` para `onCriarVale`/`onCriarAdiantamento`/`onCancelarAdiantamento`. O hook `useFolhaFuncionario` expõe `mutateAsync` que retorna `Promise<Vale>` e `Promise<Adiantamento>` — TypeScript rejeita atribuição para `Promise<void>`. Solução: `Promise<unknown>` é structural-compatible e não força wrapping desnecessário no page. Sem impacto funcional.
+
+---
+
+## Decisões tomadas durante a execução
+
+- **`fecharMes()` NÃO adicionado em `folha.ts`**: o plano de FE-017 explicita que ele adicionará a função `fecharMes()` em `folha.ts`. FE-016 só expõe `invalidarPosFechamento()` para FE-017 usar após o POST.
+- **`valorTotal` computado no AdiantamentoForm**: usuário preenche `valorParcela × numParcelas`; total é calculado e exibido como preview antes de submeter. Evita erro do usuário ao somar manualmente.
+- **ModalFechamento stub com interface completa**: props definidas são o contrato que FE-017 seguirá sem alteração — `open, funcionarioId, mes, salarioBase, totalVales, listaAdiantamentosAtivos, onClose, onConfirmado`.
+- **`parcelasPagas + 1` na exibição da parcela corrente**: `parcelasPagas=0` = 1ª parcela pendente → exibido como `1/N`. Faz sentido semântico para o usuário ("você está na parcela 1 de 3").
+- **Endpoint DELETE**: `/api/funcionarios/adiantamentos/{id}` — verificado no `FolhaController.java` (prefix `/api/funcionarios` + `@DeleteMapping("/adiantamentos/{adiantamentoId}")`). Plano havia anotado `/api/adiantamentos/{id}` (incorreto).
+- **Decisão §7 (vales na lista do Pedro)**: Opção A aprovada pelo PO — vales NÃO aparecem na lista do Pedro; `Home.tsx` intocado. Anotado no plano FE-016.
+
+---
+
+## Decisões pendentes (esperando humano)
+
+Nenhuma — tarefa fechada.
+
+---
+
+## Próximos passos / observações pro próximo
+
+**FE-017** (ModalFechamento):
+- Interface de props já definida em `ModalFechamento.tsx` — seguir sem alterar
+- Adicionar `fecharMes(funcionarioId, mes, ajuste)` em `src/api/folha.ts`
+- Após POST bem-sucedido, chamar `invalidarPosFechamento()` disponível no hook
+- `totalVales` passado ao modal já exclui vales fechados (`vale.fechado === false`)
+- Erro 409 = mês já fechado; mapear para mensagem clara
+
+---
+
+## Padrões técnicos
+
+**Padrão: Props-down data flow (Prop Drilling controlado)**
+As seções (`ValesSection`, `AdiantamentosSection`, `FechamentosSection`) recebem dados e handlers via props, sem queries internas. Toda a orquestração fica no `useFolhaFuncionario` hook. Esse padrão favorece testabilidade (seções testáveis como pure components sem mock de queries) e separa responsabilidade de fetch do rendering.
+
+**Hook agregador com queries independentes:**
+TanStack Query com 4 `useQuery` independentes — cada seção tem seu próprio loading/error state. O `isLoading` combinado só bloqueia a tela inicial (loading splash). Após carregar, falha isolada em uma query não derruba as demais.
+
+**`mesFechado` derivado por string prefix:**
+`mesReferencia` vem do backend como `"YYYY-MM-DD"` (LocalDate first day of month). Comparação `f.mesReferencia.startsWith(mesSelecionado)` onde `mesSelecionado` é `"YYYY-MM"` — adequado e sem overhead de parse de data.
+
+---
+
+## Arquivos criados/modificados
+
+- `src/types/folha.ts` (modificado: Vale, ValeRequest, Adiantamento, AdiantamentoRequest, Fechamento)
+- `src/api/folha.ts` (modificado: 6 funções de API adicionadas)
+- `src/hooks/folha/useFolhaFuncionario.ts` (novo)
+- `src/components/folha/ValeForm.tsx` (novo)
+- `src/components/folha/AdiantamentoForm.tsx` (novo)
+- `src/components/folha/ValesSection.tsx` (novo)
+- `src/components/folha/AdiantamentosSection.tsx` (novo)
+- `src/components/folha/FechamentosSection.tsx` (novo)
+- `src/components/folha/ModalFechamento.tsx` (novo — stub FE-017)
+- `src/components/folha/FolhaFuncionario.test.tsx` (novo — 8 testes)
+- `src/paginas/folha/FolhaFuncionarioPage.tsx` (modificado: implementação completa)

--- a/frontend/src/api/folha.ts
+++ b/frontend/src/api/folha.ts
@@ -12,7 +12,15 @@
  */
 
 import { client } from './client'
-import type { Funcionario, FuncionarioRequest } from '../types/folha'
+import type {
+  Funcionario,
+  FuncionarioRequest,
+  Vale,
+  ValeRequest,
+  Adiantamento,
+  AdiantamentoRequest,
+  Fechamento,
+} from '../types/folha'
 
 // ── Funcionários ──────────────────────────────────────────────────────────────
 
@@ -36,7 +44,38 @@ export async function desativarFuncionario(id: number): Promise<void> {
   return client.delete<void>(`/api/funcionarios/${id}`)
 }
 
-// ── Extensões futuras (FE-016) ────────────────────────────────────────────────
-// listarVales(), criarVale(), listarAdiantamentos(), criarAdiantamento(),
-// cancelarAdiantamento(), listarFechamentos(), fecharMes()
-// serão adicionadas neste arquivo por FE-016.
+// ── Vales (FE-016) ────────────────────────────────────────────────────────────
+
+export async function listarVales(funcionarioId: number, mes: string): Promise<Vale[]> {
+  return client.get<Vale[]>(`/api/funcionarios/${funcionarioId}/vales`, { mes })
+}
+
+export async function criarVale(funcionarioId: number, data: ValeRequest): Promise<Vale> {
+  return client.post<Vale>(`/api/funcionarios/${funcionarioId}/vales`, data)
+}
+
+// ── Adiantamentos (FE-016) ────────────────────────────────────────────────────
+
+export async function listarAdiantamentos(funcionarioId: number): Promise<Adiantamento[]> {
+  return client.get<Adiantamento[]>(`/api/funcionarios/${funcionarioId}/adiantamentos`)
+}
+
+export async function criarAdiantamento(
+  funcionarioId: number,
+  data: AdiantamentoRequest,
+): Promise<Adiantamento> {
+  return client.post<Adiantamento>(`/api/funcionarios/${funcionarioId}/adiantamentos`, data)
+}
+
+/** DELETE /api/funcionarios/adiantamentos/{adiantamentoId} → 204 No Content */
+export async function cancelarAdiantamento(adiantamentoId: number): Promise<void> {
+  return client.delete<void>(`/api/funcionarios/adiantamentos/${adiantamentoId}`)
+}
+
+// ── Fechamentos (FE-016) ──────────────────────────────────────────────────────
+
+export async function listarFechamentos(funcionarioId: number): Promise<Fechamento[]> {
+  return client.get<Fechamento[]>(`/api/funcionarios/${funcionarioId}/fechamentos`)
+}
+
+// fecharMes() será adicionado por FE-017 (POST /api/funcionarios/{id}/fechamentos)

--- a/frontend/src/components/folha/AdiantamentoForm.tsx
+++ b/frontend/src/components/folha/AdiantamentoForm.tsx
@@ -1,0 +1,154 @@
+/**
+ * AdiantamentoForm — formulário inline para registrar um adiantamento parcelado (FE-016).
+ *
+ * Campos: descrição, valor da parcela, nº de parcelas (total calculado), data de início.
+ * valorTotal é computado (valorParcela × numParcelas) e enviado ao backend.
+ * Não usa react-hook-form — campos controlados com useState.
+ */
+
+import { useState } from 'react'
+import { formatarMoeda } from '../../lib/formato'
+import type { AdiantamentoRequest } from '../../types/folha'
+
+interface AdiantamentoFormProps {
+  onSubmit: (data: AdiantamentoRequest) => Promise<void>
+  onCancelar: () => void
+}
+
+function dataHoje(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+export function AdiantamentoForm({ onSubmit, onCancelar }: AdiantamentoFormProps) {
+  const [descricao, setDescricao] = useState('')
+  const [valorParcela, setValorParcela] = useState('')
+  const [numParcelas, setNumParcelas] = useState('')
+  const [dataInicio, setDataInicio] = useState(dataHoje())
+  const [salvando, setSalvando] = useState(false)
+  const [erro, setErro] = useState<string | null>(null)
+
+  const valorParcelaNum = parseFloat(valorParcela) || 0
+  const numParcelasNum = parseInt(numParcelas) || 0
+  const valorTotal = valorParcelaNum * numParcelasNum
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!descricao.trim() || !valorParcela || !numParcelas) return
+
+    setSalvando(true)
+    setErro(null)
+    try {
+      await onSubmit({
+        descricao: descricao.trim(),
+        valorTotal,
+        valorParcela: valorParcelaNum,
+        numParcelas: numParcelasNum,
+        dataInicio,
+      })
+    } catch {
+      setErro('Erro ao registrar adiantamento. Tente novamente.')
+    } finally {
+      setSalvando(false)
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      data-testid="adiantamento-form"
+      className="bg-zinc-50 rounded-xl p-4 space-y-3 border border-zinc-200"
+    >
+      <p className="text-sm font-medium text-zinc-700">Novo adiantamento parcelado</p>
+
+      <div>
+        <label htmlFor="adt-descricao" className="block text-xs text-zinc-500 mb-1">
+          Descrição *
+        </label>
+        <input
+          id="adt-descricao"
+          type="text"
+          value={descricao}
+          onChange={(e) => setDescricao(e.target.value)}
+          required
+          className="w-full rounded-lg border border-zinc-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder="Ex: óculos"
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label htmlFor="adt-parcela" className="block text-xs text-zinc-500 mb-1">
+            Valor da parcela (R$) *
+          </label>
+          <input
+            id="adt-parcela"
+            type="number"
+            min="0.01"
+            step="0.01"
+            value={valorParcela}
+            onChange={(e) => setValorParcela(e.target.value)}
+            required
+            className="w-full rounded-lg border border-zinc-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder="0,00"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="adt-num-parcelas" className="block text-xs text-zinc-500 mb-1">
+            Nº de parcelas *
+          </label>
+          <input
+            id="adt-num-parcelas"
+            type="number"
+            min="1"
+            step="1"
+            value={numParcelas}
+            onChange={(e) => setNumParcelas(e.target.value)}
+            required
+            className="w-full rounded-lg border border-zinc-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder="1"
+          />
+        </div>
+      </div>
+
+      {valorTotal > 0 && (
+        <p className="text-xs text-zinc-500">
+          Total: <span className="font-semibold text-zinc-700">{formatarMoeda(valorTotal)}</span>
+        </p>
+      )}
+
+      <div>
+        <label htmlFor="adt-data-inicio" className="block text-xs text-zinc-500 mb-1">
+          Início dos descontos *
+        </label>
+        <input
+          id="adt-data-inicio"
+          type="date"
+          value={dataInicio}
+          onChange={(e) => setDataInicio(e.target.value)}
+          required
+          className="w-full rounded-lg border border-zinc-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </div>
+
+      {erro && <p className="text-xs text-red-600">{erro}</p>}
+
+      <div className="flex gap-2 pt-1">
+        <button
+          type="submit"
+          disabled={salvando}
+          className="flex-1 bg-blue-600 text-white text-sm font-medium py-2 rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+        >
+          {salvando ? 'Salvando…' : 'Salvar adiantamento'}
+        </button>
+        <button
+          type="button"
+          onClick={onCancelar}
+          className="px-4 text-sm text-zinc-600 hover:text-zinc-900 transition-colors"
+        >
+          Cancelar
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/frontend/src/components/folha/AdiantamentosSection.tsx
+++ b/frontend/src/components/folha/AdiantamentosSection.tsx
@@ -1,0 +1,117 @@
+/**
+ * AdiantamentosSection — exibe adiantamentos ativos do funcionário (FE-016).
+ *
+ * Props: recebe dados prontos do useFolhaFuncionario hook.
+ */
+
+import { useState } from 'react'
+import { formatarMoeda } from '../../lib/formato'
+import { AdiantamentoForm } from './AdiantamentoForm'
+import type { Adiantamento, AdiantamentoRequest } from '../../types/folha'
+
+interface AdiantamentosSectionProps {
+  adiantamentos: Adiantamento[]
+  onCriarAdiantamento: (data: AdiantamentoRequest) => Promise<unknown>
+  onCancelarAdiantamento: (id: number) => Promise<unknown>
+}
+
+export function AdiantamentosSection({
+  adiantamentos,
+  onCriarAdiantamento,
+  onCancelarAdiantamento,
+}: AdiantamentosSectionProps) {
+  const [formAberto, setFormAberto] = useState(false)
+  const [cancelando, setCancelando] = useState<number | null>(null)
+
+  async function handleCriarAdiantamento(data: AdiantamentoRequest) {
+    await onCriarAdiantamento(data)
+    setFormAberto(false)
+  }
+
+  async function handleCancelar(id: number) {
+    if (!confirm('Cancelar este adiantamento? As parcelas restantes não serão descontadas.')) {
+      return
+    }
+    setCancelando(id)
+    try {
+      await onCancelarAdiantamento(id)
+    } finally {
+      setCancelando(null)
+    }
+  }
+
+  return (
+    <section aria-labelledby="adt-titulo" data-testid="adiantamentos-section">
+      {/* Cabeçalho */}
+      <div className="flex items-center justify-between mb-3">
+        <h2 id="adt-titulo" className="text-base font-semibold text-zinc-800">
+          Adiantamentos ativos
+        </h2>
+        <button
+          onClick={() => setFormAberto((v) => !v)}
+          className="text-xs font-medium text-blue-600 hover:text-blue-800 transition-colors"
+          aria-label="Novo adiantamento"
+        >
+          + Novo adiantamento
+        </button>
+      </div>
+
+      {/* Formulário inline */}
+      {formAberto && (
+        <div className="mb-3">
+          <AdiantamentoForm
+            onSubmit={handleCriarAdiantamento}
+            onCancelar={() => setFormAberto(false)}
+          />
+        </div>
+      )}
+
+      {/* Lista */}
+      {adiantamentos.length === 0 ? (
+        <p className="text-sm text-zinc-400 py-4 text-center" data-testid="adiantamentos-vazio">
+          Nenhum adiantamento ativo.
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {adiantamentos.map((adt) => (
+            <li
+              key={adt.id}
+              data-testid={`adiantamento-item-${adt.id}`}
+              className="bg-white border border-zinc-100 rounded-xl px-4 py-3"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-zinc-800 truncate">{adt.descricao}</p>
+                  <p className="text-xs text-zinc-400 mt-0.5">
+                    Parcela{' '}
+                    <span
+                      className="font-semibold text-zinc-600"
+                      data-testid={`parcela-${adt.id}`}
+                    >
+                      {adt.parcelasPagas + 1}/{adt.numParcelas}
+                    </span>{' '}
+                    · {formatarMoeda(adt.valorParcela)}/mês
+                  </p>
+                </div>
+                <div className="flex flex-col items-end gap-1 shrink-0">
+                  <span className="text-sm font-semibold text-zinc-800">
+                    {formatarMoeda(adt.valorTotal)}
+                  </span>
+                  <button
+                    onClick={() => handleCancelar(adt.id)}
+                    disabled={cancelando === adt.id}
+                    className="text-xs text-red-500 hover:text-red-700 disabled:opacity-50 transition-colors"
+                    aria-label={`Cancelar adiantamento ${adt.descricao}`}
+                    data-testid={`btn-cancelar-${adt.id}`}
+                  >
+                    {cancelando === adt.id ? 'Cancelando…' : 'Cancelar'}
+                  </button>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/components/folha/FechamentosSection.tsx
+++ b/frontend/src/components/folha/FechamentosSection.tsx
@@ -1,0 +1,104 @@
+/**
+ * FechamentosSection — exibe histórico de fechamentos mensais (Pedidos FOLHA) em accordion (FE-016).
+ *
+ * Props: recebe dados prontos do useFolhaFuncionario hook.
+ * Ordenação por mes_referencia DESC assumida (backend já retorna nessa ordem).
+ */
+
+import { useState } from 'react'
+import { format, parseISO } from 'date-fns'
+import { ptBR } from 'date-fns/locale'
+import { formatarMoeda } from '../../lib/formato'
+import type { Fechamento } from '../../types/folha'
+
+interface FechamentosSectionProps {
+  fechamentos: Fechamento[]
+}
+
+const STATUS_BADGE: Record<string, string> = {
+  PENDENTE: 'bg-yellow-100 text-yellow-700',
+  PAGO: 'bg-green-100 text-green-700',
+  CANCELADO: 'bg-zinc-100 text-zinc-500',
+}
+
+export function FechamentosSection({ fechamentos }: FechamentosSectionProps) {
+  const [expandido, setExpandido] = useState<number | null>(null)
+
+  function toggleExpandir(id: number) {
+    setExpandido((prev) => (prev === id ? null : id))
+  }
+
+  return (
+    <section aria-labelledby="fechamentos-titulo" data-testid="fechamentos-section">
+      <h2 id="fechamentos-titulo" className="text-base font-semibold text-zinc-800 mb-3">
+        Fechamentos anteriores
+      </h2>
+
+      {fechamentos.length === 0 ? (
+        <p className="text-sm text-zinc-400 py-4 text-center" data-testid="fechamentos-vazio">
+          Nenhum fechamento realizado.
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {fechamentos.map((f) => {
+            const aberto = expandido === f.id
+            const mesLabel = format(parseISO(f.mesReferencia), "MMMM 'de' yyyy", { locale: ptBR })
+
+            return (
+              <li
+                key={f.id}
+                data-testid={`fechamento-item-${f.id}`}
+                className="bg-white border border-zinc-100 rounded-xl overflow-hidden"
+              >
+                {/* Linha principal — clique abre/fecha */}
+                <button
+                  onClick={() => toggleExpandir(f.id)}
+                  aria-expanded={aberto}
+                  className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-zinc-50 transition-colors"
+                  data-testid={`btn-expandir-${f.id}`}
+                >
+                  <div>
+                    <p className="text-sm font-medium text-zinc-800 capitalize">{mesLabel}</p>
+                    <span
+                      className={`mt-0.5 inline-block text-xs font-medium px-2 py-0.5 rounded-full ${STATUS_BADGE[f.status] ?? 'bg-zinc-100 text-zinc-500'}`}
+                    >
+                      {f.status}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <span className="text-sm font-semibold text-zinc-800">
+                      {formatarMoeda(f.valor)}
+                    </span>
+                    <svg
+                      className={`w-4 h-4 text-zinc-400 transition-transform ${aberto ? 'rotate-180' : ''}`}
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                      aria-hidden="true"
+                    >
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                    </svg>
+                  </div>
+                </button>
+
+                {/* Observação expandida */}
+                {aberto && (
+                  <div
+                    className="border-t border-zinc-100 px-4 py-3 bg-zinc-50"
+                    data-testid={`observacao-${f.id}`}
+                  >
+                    {f.observacao ? (
+                      <p className="text-xs text-zinc-600 whitespace-pre-line">{f.observacao}</p>
+                    ) : (
+                      <p className="text-xs text-zinc-400 italic">Sem detalhes disponíveis.</p>
+                    )}
+                  </div>
+                )}
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/components/folha/FolhaFuncionario.test.tsx
+++ b/frontend/src/components/folha/FolhaFuncionario.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * FolhaFuncionario.test.tsx — testes das seções de ValesSection, AdiantamentosSection
+ * e FechamentosSection (FE-016).
+ *
+ * As seções recebem dados via props — sem necessidade de mock de queries.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { ValesSection } from './ValesSection'
+import { AdiantamentosSection } from './AdiantamentosSection'
+import { FechamentosSection } from './FechamentosSection'
+import type { Vale, Adiantamento, Fechamento } from '../../types/folha'
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const valeAberto: Vale = {
+  id: 1,
+  funcionarioId: 10,
+  categoria: 'VALE',
+  descricao: 'Mercado',
+  valor: 150,
+  status: 'PENDENTE',
+  fechado: false,
+  dataPedido: '2026-06-03',
+  dataCriacao: '2026-06-03T10:00:00',
+}
+
+const valeFechado: Vale = {
+  ...valeAberto,
+  id: 2,
+  descricao: 'Farmácia',
+  valor: 80,
+  fechado: true,
+  status: 'PAGO',
+}
+
+const adiantamentoAtivo: Adiantamento = {
+  id: 5,
+  funcionarioId: 10,
+  descricao: 'Óculos',
+  valorTotal: 600,
+  valorParcela: 200,
+  numParcelas: 3,
+  parcelasPagas: 1,
+  parcelasRestantes: 2,
+  dataInicio: '2026-05-01',
+  ativo: true,
+  criadoEm: '2026-05-01T09:00:00',
+}
+
+const fechamento: Fechamento = {
+  id: 20,
+  funcionarioId: 10,
+  valor: 1700,
+  status: 'PENDENTE',
+  observacao: 'salário R$2000 - vales R$150 - adiantamentos R$200 + ajuste R$50',
+  mesReferencia: '2026-05-01',
+  dataCriacao: '2026-06-01T12:00:00',
+}
+
+// ── ValesSection ──────────────────────────────────────────────────────────────
+
+describe('ValesSection — estado vazio', () => {
+  it('exibe mensagem de estado vazio quando não há vales', () => {
+    render(
+      <ValesSection
+        vales={[]}
+        mesSelecionado="2026-06"
+        onMesChange={vi.fn()}
+        onCriarVale={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('vales-vazio')).toBeInTheDocument()
+  })
+})
+
+describe('ValesSection — lista de vales', () => {
+  it('renderiza vales e aplica classe de tachado nos fechados', () => {
+    render(
+      <ValesSection
+        vales={[valeAberto, valeFechado]}
+        mesSelecionado="2026-06"
+        onMesChange={vi.fn()}
+        onCriarVale={vi.fn()}
+      />,
+    )
+
+    // Vale aberto — sem tachado
+    const itemAberto = screen.getByTestId('vale-item-1')
+    expect(itemAberto).toBeInTheDocument()
+    expect(screen.queryByTestId('vale-fechado')).toBeInTheDocument() // vale fechado marcado
+
+    // Vale fechado tem data-testid="vale-fechado"
+    const itemFechado = screen.getByTestId('vale-item-2')
+    expect(itemFechado).toBeInTheDocument()
+  })
+
+  it('clicar em "+ Registrar vale" exibe ValeForm', () => {
+    render(
+      <ValesSection
+        vales={[]}
+        mesSelecionado="2026-06"
+        onMesChange={vi.fn()}
+        onCriarVale={vi.fn()}
+      />,
+    )
+    expect(screen.queryByTestId('vale-form')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /registrar vale/i }))
+    expect(screen.getByTestId('vale-form')).toBeInTheDocument()
+  })
+
+  it('cancelar ValeForm oculta o formulário', () => {
+    render(
+      <ValesSection
+        vales={[]}
+        mesSelecionado="2026-06"
+        onMesChange={vi.fn()}
+        onCriarVale={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /registrar vale/i }))
+    expect(screen.getByTestId('vale-form')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /cancelar/i }))
+    expect(screen.queryByTestId('vale-form')).not.toBeInTheDocument()
+  })
+})
+
+// ── AdiantamentosSection ──────────────────────────────────────────────────────
+
+describe('AdiantamentosSection — lista de adiantamentos', () => {
+  it('renderiza adiantamento com parcela X/total correta', () => {
+    render(
+      <AdiantamentosSection
+        adiantamentos={[adiantamentoAtivo]}
+        onCriarAdiantamento={vi.fn()}
+        onCancelarAdiantamento={vi.fn()}
+      />,
+    )
+
+    // parcelasPagas=1, numParcelas=3 → deve mostrar "2/3" (próxima parcela a ser paga)
+    const parcelaEl = screen.getByTestId('parcela-5')
+    expect(parcelaEl).toHaveTextContent('2/3')
+  })
+
+  it('botão cancelar chama onCancelarAdiantamento com o id correto', async () => {
+    const onCancelar = vi.fn().mockResolvedValue(undefined)
+    window.confirm = vi.fn().mockReturnValue(true)
+
+    render(
+      <AdiantamentosSection
+        adiantamentos={[adiantamentoAtivo]}
+        onCriarAdiantamento={vi.fn()}
+        onCancelarAdiantamento={onCancelar}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId('btn-cancelar-5'))
+
+    await waitFor(() => {
+      expect(onCancelar).toHaveBeenCalledWith(5)
+    })
+  })
+})
+
+// ── FechamentosSection ─────────────────────────────────────────────────────────
+
+describe('FechamentosSection — histórico de fechamentos', () => {
+  it('renderiza fechamento com mês de referência e valor', () => {
+    render(<FechamentosSection fechamentos={[fechamento]} />)
+
+    const item = screen.getByTestId('fechamento-item-20')
+    expect(item).toBeInTheDocument()
+    // Deve exibir "maio de 2026" (mes_referencia = "2026-05-01")
+    expect(item).toHaveTextContent(/maio/i)
+  })
+
+  it('clicar no fechamento expande a observação (accordion)', () => {
+    render(<FechamentosSection fechamentos={[fechamento]} />)
+
+    // Observação não aparece antes do clique
+    expect(screen.queryByTestId('observacao-20')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('btn-expandir-20'))
+    expect(screen.getByTestId('observacao-20')).toBeInTheDocument()
+    expect(screen.getByTestId('observacao-20')).toHaveTextContent(/salário/)
+  })
+})

--- a/frontend/src/components/folha/ModalFechamento.tsx
+++ b/frontend/src/components/folha/ModalFechamento.tsx
@@ -1,0 +1,53 @@
+/**
+ * ModalFechamento — STUB para FE-017.
+ *
+ * Interface de props estabelecida por FE-016 para contratos com FolhaFuncionarioPage.
+ * FE-017 substitui este stub pela implementação completa com:
+ *   - preview em tempo real (salário - vales - parcelas adiantamentos + ajuste)
+ *   - alerta para valor negativo
+ *   - POST /api/funcionarios/{id}/fechamentos
+ *   - toast de confirmação
+ *
+ * Props definidas aqui são o contrato que FE-017 deve seguir sem alteração.
+ */
+
+import type { Adiantamento, Fechamento } from '../../types/folha'
+
+export interface ModalFechamentoProps {
+  open: boolean
+  funcionarioId: number
+  mes: string                          // "YYYY-MM" (ex: "2026-06")
+  salarioBase: number
+  totalVales: number                   // soma dos vales abertos do mês
+  listaAdiantamentosAtivos: Adiantamento[]
+  onClose: () => void
+  onConfirmado: (fechamento: Fechamento) => void
+}
+
+export function ModalFechamento({ open, mes, onClose }: ModalFechamentoProps) {
+  if (!open) return null
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Fechar mês ${mes}`}
+      className="fixed inset-0 z-50 flex items-end justify-center bg-black/50"
+    >
+      <div className="bg-white rounded-t-2xl w-full max-w-md p-6 pb-8">
+        <p className="text-sm font-semibold text-zinc-800 mb-2">
+          Fechar mês {mes}
+        </p>
+        <p className="text-xs text-zinc-400 mb-6">
+          Implementação completa disponível na task FE-017.
+        </p>
+        <button
+          onClick={onClose}
+          className="w-full text-sm text-zinc-500 border border-zinc-200 rounded-xl py-2 hover:bg-zinc-50 transition-colors"
+        >
+          Fechar
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/folha/ValeForm.tsx
+++ b/frontend/src/components/folha/ValeForm.tsx
@@ -1,0 +1,119 @@
+/**
+ * ValeForm — formulário inline para registrar um vale (FE-016).
+ *
+ * Campos: descrição, valor, data do pedido (default: hoje).
+ * Não usa react-hook-form — campos controlados com useState.
+ */
+
+import { useState } from 'react'
+import type { ValeRequest } from '../../types/folha'
+
+interface ValeFormProps {
+  onSubmit: (data: ValeRequest) => Promise<void>
+  onCancelar: () => void
+}
+
+function dataHoje(): string {
+  return new Date().toISOString().slice(0, 10) // "YYYY-MM-DD"
+}
+
+export function ValeForm({ onSubmit, onCancelar }: ValeFormProps) {
+  const [descricao, setDescricao] = useState('')
+  const [valor, setValor] = useState('')
+  const [dataPedido, setDataPedido] = useState(dataHoje())
+  const [salvando, setSalvando] = useState(false)
+  const [erro, setErro] = useState<string | null>(null)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!descricao.trim() || !valor) return
+
+    setSalvando(true)
+    setErro(null)
+    try {
+      await onSubmit({
+        descricao: descricao.trim(),
+        valor: parseFloat(valor),
+        dataPedido,
+      })
+    } catch {
+      setErro('Erro ao registrar vale. Tente novamente.')
+    } finally {
+      setSalvando(false)
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      data-testid="vale-form"
+      className="bg-zinc-50 rounded-xl p-4 space-y-3 border border-zinc-200"
+    >
+      <p className="text-sm font-medium text-zinc-700">Registrar vale</p>
+
+      <div>
+        <label htmlFor="vale-descricao" className="block text-xs text-zinc-500 mb-1">
+          Descrição *
+        </label>
+        <input
+          id="vale-descricao"
+          type="text"
+          value={descricao}
+          onChange={(e) => setDescricao(e.target.value)}
+          required
+          className="w-full rounded-lg border border-zinc-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder="Ex: adiantamento pessoal"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="vale-valor" className="block text-xs text-zinc-500 mb-1">
+          Valor (R$) *
+        </label>
+        <input
+          id="vale-valor"
+          type="number"
+          min="0.01"
+          step="0.01"
+          value={valor}
+          onChange={(e) => setValor(e.target.value)}
+          required
+          className="w-full rounded-lg border border-zinc-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder="0,00"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="vale-data" className="block text-xs text-zinc-500 mb-1">
+          Data
+        </label>
+        <input
+          id="vale-data"
+          type="date"
+          value={dataPedido}
+          onChange={(e) => setDataPedido(e.target.value)}
+          className="w-full rounded-lg border border-zinc-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </div>
+
+      {erro && <p className="text-xs text-red-600">{erro}</p>}
+
+      <div className="flex gap-2 pt-1">
+        <button
+          type="submit"
+          disabled={salvando}
+          className="flex-1 bg-blue-600 text-white text-sm font-medium py-2 rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+        >
+          {salvando ? 'Salvando…' : 'Salvar vale'}
+        </button>
+        <button
+          type="button"
+          onClick={onCancelar}
+          className="px-4 text-sm text-zinc-600 hover:text-zinc-900 transition-colors"
+        >
+          Cancelar
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/frontend/src/components/folha/ValesSection.tsx
+++ b/frontend/src/components/folha/ValesSection.tsx
@@ -1,0 +1,120 @@
+/**
+ * ValesSection — exibe vales do mês selecionado + seletor de mês + botão registrar vale (FE-016).
+ *
+ * Props: recebe dados prontos do useFolhaFuncionario hook (sem query interna).
+ */
+
+import { useState } from 'react'
+import { format, parseISO } from 'date-fns'
+import { ptBR } from 'date-fns/locale'
+import { formatarMoeda } from '../../lib/formato'
+import { ValeForm } from './ValeForm'
+import type { Vale, ValeRequest } from '../../types/folha'
+
+interface ValesSectionProps {
+  vales: Vale[]
+  mesSelecionado: string          // "YYYY-MM"
+  onMesChange: (mes: string) => void
+  onCriarVale: (data: ValeRequest) => Promise<unknown>
+}
+
+/** Gera os últimos N meses no formato "YYYY-MM" (mais recente primeiro) */
+function gerarMeses(n: number): { valor: string; label: string }[] {
+  const hoje = new Date()
+  return Array.from({ length: n }, (_, i) => {
+    const d = new Date(hoje.getFullYear(), hoje.getMonth() - i, 1)
+    const valor = format(d, 'yyyy-MM')
+    const label = format(d, "MMM/yyyy", { locale: ptBR }).replace('.', '')
+    return { valor, label }
+  })
+}
+
+const MESES_OPCOES = gerarMeses(6)
+
+export function ValesSection({ vales, mesSelecionado, onMesChange, onCriarVale }: ValesSectionProps) {
+  const [formAberto, setFormAberto] = useState(false)
+
+  async function handleCriarVale(data: ValeRequest) {
+    await onCriarVale(data)
+    setFormAberto(false)
+  }
+
+  return (
+    <section aria-labelledby="vales-titulo" data-testid="vales-section">
+      {/* Cabeçalho da seção */}
+      <div className="flex items-center justify-between mb-3">
+        <h2 id="vales-titulo" className="text-base font-semibold text-zinc-800">
+          Vales do mês
+        </h2>
+        <button
+          onClick={() => setFormAberto((v) => !v)}
+          className="text-xs font-medium text-blue-600 hover:text-blue-800 transition-colors"
+          aria-label="Registrar vale"
+        >
+          + Registrar vale
+        </button>
+      </div>
+
+      {/* Seletor de mês */}
+      <div className="mb-3">
+        <select
+          value={mesSelecionado}
+          onChange={(e) => onMesChange(e.target.value)}
+          aria-label="Mês de referência"
+          className="text-sm rounded-lg border border-zinc-200 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
+        >
+          {MESES_OPCOES.map(({ valor, label }) => (
+            <option key={valor} value={valor}>
+              {label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Formulário inline */}
+      {formAberto && (
+        <div className="mb-3">
+          <ValeForm onSubmit={handleCriarVale} onCancelar={() => setFormAberto(false)} />
+        </div>
+      )}
+
+      {/* Lista de vales */}
+      {vales.length === 0 ? (
+        <p className="text-sm text-zinc-400 py-4 text-center" data-testid="vales-vazio">
+          Nenhum vale registrado neste mês.
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {vales.map((vale) => (
+            <li
+              key={vale.id}
+              data-testid={`vale-item-${vale.id}`}
+              className={`flex items-center justify-between rounded-xl px-4 py-3 ${
+                vale.fechado
+                  ? 'bg-zinc-50 text-zinc-400'
+                  : 'bg-white border border-zinc-100 text-zinc-700'
+              }`}
+            >
+              <div>
+                <p
+                  className={`text-sm font-medium ${vale.fechado ? 'line-through text-zinc-400' : 'text-zinc-800'}`}
+                  data-testid={vale.fechado ? 'vale-fechado' : undefined}
+                >
+                  {vale.descricao}
+                </p>
+                <p className="text-xs text-zinc-400 mt-0.5">
+                  {format(parseISO(vale.dataPedido), "d 'de' MMM", { locale: ptBR })}
+                </p>
+              </div>
+              <span
+                className={`text-sm font-semibold ${vale.fechado ? 'text-zinc-400 line-through' : 'text-red-600'}`}
+              >
+                {formatarMoeda(vale.valor)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/hooks/folha/useFolhaFuncionario.ts
+++ b/frontend/src/hooks/folha/useFolhaFuncionario.ts
@@ -1,0 +1,98 @@
+/**
+ * useFolhaFuncionario — hook agregador das queries e mutations da Tela Folha (FE-016).
+ *
+ * Agrega 4 queries independentes: funcionário, vales do mês, adiantamentos ativos, fechamentos.
+ * Expõe mutations para criar vale, criar adiantamento e cancelar adiantamento.
+ * fecharMes() é adicionado por FE-017.
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  buscarFuncionario,
+  listarVales,
+  criarVale,
+  listarAdiantamentos,
+  criarAdiantamento,
+  cancelarAdiantamento,
+  listarFechamentos,
+} from '../../api/folha'
+import type { ValeRequest, AdiantamentoRequest } from '../../types/folha'
+
+export function useFolhaFuncionario(funcionarioId: number, mesSelecionado: string) {
+  const qc = useQueryClient()
+
+  const funcionarioQuery = useQuery({
+    queryKey: ['funcionario', funcionarioId],
+    queryFn: () => buscarFuncionario(funcionarioId),
+    staleTime: 60_000,
+  })
+
+  const valesQuery = useQuery({
+    queryKey: ['vales', funcionarioId, mesSelecionado],
+    queryFn: () => listarVales(funcionarioId, mesSelecionado),
+    staleTime: 30_000,
+  })
+
+  const adiantamentosQuery = useQuery({
+    queryKey: ['adiantamentos', funcionarioId],
+    queryFn: () => listarAdiantamentos(funcionarioId),
+    staleTime: 30_000,
+  })
+
+  const fechamentosQuery = useQuery({
+    queryKey: ['fechamentos', funcionarioId],
+    queryFn: () => listarFechamentos(funcionarioId),
+    staleTime: 30_000,
+  })
+
+  const criarValeMutation = useMutation({
+    mutationFn: (data: ValeRequest) => criarVale(funcionarioId, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['vales', funcionarioId] })
+    },
+  })
+
+  const criarAdiantamentoMutation = useMutation({
+    mutationFn: (data: AdiantamentoRequest) => criarAdiantamento(funcionarioId, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['adiantamentos', funcionarioId] })
+    },
+  })
+
+  const cancelarAdiantamentoMutation = useMutation({
+    mutationFn: (adiantamentoId: number) => cancelarAdiantamento(adiantamentoId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['adiantamentos', funcionarioId] })
+    },
+  })
+
+  /**
+   * mesFechado: true se já existe um Pedido FOLHA para o mês selecionado.
+   * mesReferencia vem como "YYYY-MM-DD" (primeiro dia do mês); compara prefixo "YYYY-MM".
+   */
+  const mesFechado = (fechamentosQuery.data ?? []).some((f) =>
+    f.mesReferencia.startsWith(mesSelecionado),
+  )
+
+  return {
+    funcionario: funcionarioQuery.data,
+    vales: valesQuery.data ?? [],
+    adiantamentos: adiantamentosQuery.data ?? [],
+    fechamentos: fechamentosQuery.data ?? [],
+    isLoading:
+      funcionarioQuery.isLoading ||
+      valesQuery.isLoading ||
+      adiantamentosQuery.isLoading ||
+      fechamentosQuery.isLoading,
+    mesFechado,
+    criarVale: (data: ValeRequest) => criarValeMutation.mutateAsync(data),
+    criarAdiantamento: (data: AdiantamentoRequest) =>
+      criarAdiantamentoMutation.mutateAsync(data),
+    cancelarAdiantamento: (id: number) => cancelarAdiantamentoMutation.mutateAsync(id),
+    /** Invalida vales + fechamentos — chamado por FE-017 após confirmar fechamento */
+    invalidarPosFechamento: () => {
+      qc.invalidateQueries({ queryKey: ['fechamentos', funcionarioId] })
+      qc.invalidateQueries({ queryKey: ['vales', funcionarioId] })
+    },
+  }
+}

--- a/frontend/src/paginas/folha/FolhaFuncionarioPage.tsx
+++ b/frontend/src/paginas/folha/FolhaFuncionarioPage.tsx
@@ -1,17 +1,82 @@
 /**
- * FolhaFuncionarioPage — STUB para FE-016.
+ * FolhaFuncionarioPage — tela de operação do funcionário (FE-016).
  *
- * Esta página será implementada pela task FE-016 (tela de vales, adiantamentos e fechamentos).
- * O stub garante que a rota /folha/funcionarios/:id existe e é navegável a partir de FE-015.
+ * Rota: /folha/funcionarios/:id
+ * Exibe: vales do mês, adiantamentos ativos, fechamentos anteriores.
+ * Botão "Fechar mês" aparece somente se o mês selecionado ainda não foi fechado.
  */
+
+import { useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
+import { format } from 'date-fns'
+import { ptBR } from 'date-fns/locale'
+import { formatarMoeda } from '../../lib/formato'
+import { useFolhaFuncionario } from '../../hooks/folha/useFolhaFuncionario'
+import { ValesSection } from '../../components/folha/ValesSection'
+import { AdiantamentosSection } from '../../components/folha/AdiantamentosSection'
+import { FechamentosSection } from '../../components/folha/FechamentosSection'
+import { ModalFechamento } from '../../components/folha/ModalFechamento'
+import type { Fechamento } from '../../types/folha'
+
+/** Retorna o mês corrente no formato "YYYY-MM" */
+function mesCorrente(): string {
+  const hoje = new Date()
+  return `${hoje.getFullYear()}-${String(hoje.getMonth() + 1).padStart(2, '0')}`
+}
 
 export function FolhaFuncionarioPage() {
   const navigate = useNavigate()
   const { id } = useParams<{ id: string }>()
+  const funcionarioId = parseInt(id ?? '0', 10)
+
+  const [mesSelecionado, setMesSelecionado] = useState(mesCorrente)
+  const [modalAberto, setModalAberto] = useState(false)
+
+  const {
+    funcionario,
+    vales,
+    adiantamentos,
+    fechamentos,
+    isLoading,
+    mesFechado,
+    criarVale,
+    criarAdiantamento,
+    cancelarAdiantamento,
+    invalidarPosFechamento,
+  } = useFolhaFuncionario(funcionarioId, mesSelecionado)
+
+  function handleFecharMesConfirmado(fechamento: Fechamento) {
+    setModalAberto(false)
+    invalidarPosFechamento()
+    // FE-017 pode adicionar toast aqui
+    void fechamento // suppress unused warning
+  }
+
+  // Label do mês para o botão
+  const mesBotaoLabel = (() => {
+    const [ano, mes] = mesSelecionado.split('-')
+    const d = new Date(parseInt(ano), parseInt(mes) - 1, 1)
+    return format(d, "MMMM/yyyy", { locale: ptBR })
+  })()
+
+  // Total de vales abertos (para o ModalFechamento FE-017)
+  const totalValesAbertos = vales
+    .filter((v) => !v.fechado)
+    .reduce((acc, v) => acc + v.valor, 0)
+
+  if (isLoading && !funcionario) {
+    return (
+      <div className="max-w-md mx-auto bg-white min-h-screen pb-24">
+        <div className="px-5 pt-20 text-center">
+          <p className="text-sm text-zinc-400">Carregando…</p>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="max-w-md mx-auto bg-white min-h-screen pb-24">
+      {/* Header */}
       <header className="px-5 pt-6 pb-4 border-b border-zinc-100">
         <div className="flex items-center gap-3">
           <button
@@ -19,18 +84,83 @@ export function FolhaFuncionarioPage() {
             className="p-1.5 rounded-lg hover:bg-zinc-100 transition-colors"
             aria-label="Voltar para funcionários"
           >
-            <svg className="w-5 h-5 text-zinc-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <svg
+              className="w-5 h-5 text-zinc-600"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <h1 className="text-xl font-bold text-zinc-900">Folha do funcionário</h1>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2">
+              <h1 className="text-xl font-bold text-zinc-900 truncate">
+                {funcionario?.nome ?? `Funcionário #${id}`}
+              </h1>
+              {funcionario && !funcionario.contaPropria && (
+                <span className="shrink-0 text-xs font-medium bg-orange-100 text-orange-700 px-2 py-0.5 rounded-full">
+                  Conta de terceiro
+                </span>
+              )}
+            </div>
+            {funcionario && (
+              <p className="text-sm text-zinc-400 mt-0.5">
+                Salário base: {formatarMoeda(funcionario.salarioBase)}
+              </p>
+            )}
+          </div>
         </div>
       </header>
 
-      <div className="px-5 py-12 text-center text-sm text-zinc-400">
-        <p className="mb-1">Funcionário #{id}</p>
-        <p>Esta tela será implementada na task FE-016.</p>
-      </div>
+      {/* Conteúdo */}
+      <main className="px-5 py-6 space-y-8">
+        {/* Seção Vales */}
+        <ValesSection
+          vales={vales}
+          mesSelecionado={mesSelecionado}
+          onMesChange={setMesSelecionado}
+          onCriarVale={criarVale}
+        />
+
+        {/* Botão fechar mês — só aparece se o mês ainda não foi fechado */}
+        {!mesFechado && (
+          <div className="pt-1">
+            <button
+              onClick={() => setModalAberto(true)}
+              data-testid="btn-fechar-mes"
+              className="w-full bg-emerald-600 text-white text-sm font-semibold py-3 rounded-xl hover:bg-emerald-700 transition-colors"
+            >
+              Fechar mês {mesBotaoLabel}
+            </button>
+          </div>
+        )}
+
+        {/* Seção Adiantamentos */}
+        <AdiantamentosSection
+          adiantamentos={adiantamentos}
+          onCriarAdiantamento={criarAdiantamento}
+          onCancelarAdiantamento={cancelarAdiantamento}
+        />
+
+        {/* Seção Fechamentos */}
+        <FechamentosSection fechamentos={fechamentos} />
+      </main>
+
+      {/* Modal Fechamento (FE-017) */}
+      {funcionario && (
+        <ModalFechamento
+          open={modalAberto}
+          funcionarioId={funcionarioId}
+          mes={mesSelecionado}
+          salarioBase={funcionario.salarioBase}
+          totalVales={totalValesAbertos}
+          listaAdiantamentosAtivos={adiantamentos}
+          onClose={() => setModalAberto(false)}
+          onConfirmado={handleFecharMesConfirmado}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/types/folha.ts
+++ b/frontend/src/types/folha.ts
@@ -53,6 +53,63 @@ export interface FuncionarioRequest {
   diaPagamentoReferencia?: number
 }
 
-// ── Extensões futuras (FE-016) ────────────────────────────────────────────────
-// Vale, ValeRequest, Adiantamento, AdiantamentoRequest, Fechamento
-// serão adicionados neste arquivo por FE-016.
+// ── Vales ─────────────────────────────────────────────────────────────────────
+
+/** Shape do response de GET /api/funcionarios/{id}/vales (ValeResponse.java) */
+export interface Vale {
+  id: number
+  funcionarioId: number
+  categoria: string          // 'VALE'
+  descricao: string
+  valor: number              // BigDecimal → number
+  status: string             // 'PENDENTE' | 'PAGO'
+  fechado: boolean           // true = pertence a um Pedido FOLHA já fechado
+  dataPedido: string         // LocalDate → "YYYY-MM-DD"
+  dataCriacao: string        // LocalDateTime → ISO string
+}
+
+/** Body para POST /api/funcionarios/{id}/vales (ValeRequest.java) */
+export interface ValeRequest {
+  descricao: string
+  valor: number
+  dataPedido?: string        // LocalDate → "YYYY-MM-DD" (opcional no backend)
+}
+
+// ── Adiantamentos ─────────────────────────────────────────────────────────────
+
+/** Shape do response de GET /api/funcionarios/{id}/adiantamentos (AdiantamentoResponse.java) */
+export interface Adiantamento {
+  id: number
+  funcionarioId: number
+  descricao: string
+  valorTotal: number         // BigDecimal → number
+  valorParcela: number       // BigDecimal → number
+  numParcelas: number
+  parcelasPagas: number
+  parcelasRestantes: number  // campo computado pelo backend (numParcelas - parcelasPagas)
+  dataInicio: string         // LocalDate → "YYYY-MM-DD"
+  ativo: boolean
+  criadoEm: string           // LocalDateTime → ISO string
+}
+
+/** Body para POST /api/funcionarios/{id}/adiantamentos (AdiantamentoRequest.java) */
+export interface AdiantamentoRequest {
+  descricao: string
+  valorTotal: number
+  valorParcela: number
+  numParcelas: number
+  dataInicio: string         // LocalDate → "YYYY-MM-DD"
+}
+
+// ── Fechamentos ───────────────────────────────────────────────────────────────
+
+/** Shape do response de GET/POST /api/funcionarios/{id}/fechamentos (PedidoFolhaResponse.java) */
+export interface Fechamento {
+  id: number
+  funcionarioId: number
+  valor: number              // BigDecimal → number (valor líquido calculado)
+  status: string             // 'PENDENTE' | 'PAGO' | 'CANCELADO'
+  observacao: string | null  // breakdown: "salário R$X - vales R$Y - adiantamentos R$Z + ajuste R$W"
+  mesReferencia: string      // LocalDate → "YYYY-MM-DD" (primeiro dia do mês, ex: "2026-06-01")
+  dataCriacao: string        // LocalDateTime → ISO string
+}


### PR DESCRIPTION
## Summary

- Implementa a tela `/folha/funcionarios/:id` (substitui stub FE-015) com 3 seções independentes: Vales do Mês, Adiantamentos Ativos, Fechamentos Anteriores
- Hook `useFolhaFuncionario` agrega 4 queries TanStack Query + 3 mutations (criarVale, criarAdiantamento, cancelarAdiantamento)
- Botão "Fechar mês YYYY-MM" condicional — aparece somente se o mês não foi fechado; abre `ModalFechamento` (stub com interface exata para FE-017)
- 8 novos testes cobrindo ValesSection (4), AdiantamentosSection (2), FechamentosSection (2)

## Desvios

- Props das seções usam `Promise<unknown>` em vez de `Promise<void>` para compatibilidade com `mutateAsync` do TanStack Query (retorna `Promise<Vale>`/`Promise<Adiantamento>`). Sem impacto funcional.
- DELETE adiantamento: endpoint real é `/api/funcionarios/adiantamentos/{id}` (verificado em `FolhaController.java`); plano anotava `/api/adiantamentos/{id}`.

## Decisão §7 (vales na lista do Pedro)

Opção A aprovada pelo PO: vales NÃO aparecem na lista do Pedro; `Home.tsx` intocado.

## Test plan

- [x] `npm test` — 78/78 verde
- [x] `npm run lint` — limpo
- [x] `npm run build` — sem erros TS
- [x] Branch a partir de `integration/03-folha-pagamento`
- [x] Território: apenas `frontend/` + status report

🤖 Generated with [Claude Code](https://claude.com/claude-code)