### PR TITLE
feat(FE-017): ModalFechamento com calculo em tempo real

### DIFF
--- a/docs/sprints/03-folha-pagamento/status/FE-016-tela-folha-funcionario.md
+++ b/docs/sprints/03-folha-pagamento/status/FE-016-tela-folha-funcionario.md
@@ -15,8 +15,8 @@ gates:
   branch_convencao: ok
   territorio: ok
 commits:
-  - placeholder
-pr: null
+  - b0e000d
+pr: https://github.com/SSteringS/financas_bot_telegram/pull/102
 desvios: 1
 pendencias_humano: 0
 ---

--- a/docs/sprints/03-folha-pagamento/status/FE-017-modal-fechamento.md
+++ b/docs/sprints/03-folha-pagamento/status/FE-017-modal-fechamento.md
@@ -1,0 +1,83 @@
+---
+task: FE-017
+titulo: "Modal fechamento com cálculo em tempo real"
+data: 2026-06-04
+branch: feature/fe-017-modal-fechamento
+responsavel: claude-front
+estado: concluido
+gates:
+  build: ok
+  lint: ok
+  testes: ok
+  testes_total: 83
+  testes_novos: 5
+  cobertura_pct: na
+  branch_convencao: ok
+  territorio: ok
+commits:
+  - placeholder
+pr: null
+desvios: 0
+pendencias_humano: 0
+---
+
+# FE-017 — Modal fechamento com cálculo em tempo real
+
+## O que foi feito
+
+Substituído o stub `ModalFechamento.tsx` pela implementação completa com:
+- Preview de cálculo em tempo real: `salárioBase - totalVales - totalParcelas + ajuste`
+- Campo ajuste (default 0) atualiza o `valorFinal` imediatamente via `useState`
+- Alerta vermelho `[data-testid="alerta-negativo"]` quando `valorFinal < 0`
+- POST via `fecharMes()` (adicionada em `folha.ts`) com loading state no botão
+- Erro 409 → mensagem específica "Mês já fechado"
+- Callback `onConfirmado(fechamento)` dispara invalidação de cache na página
+- Toast verde em `FolhaFuncionarioPage` após fechamento confirmado (desaparece em 4s)
+- 5 novos testes no `ModalFechamento.test.tsx` com mock de `fecharMes`
+
+---
+
+## Desvios do plano
+
+Nenhum.
+
+---
+
+## Decisões tomadas durante a execução
+
+- **Toast implementado na página, não no modal**: `FolhaFuncionarioPage` gerencia o `toastSucesso` state; o modal chama `onConfirmado(fechamento)` e fecha — separação limpa de responsabilidades.
+- **`fecharMes()` recebe `ajuste: number`** (não `BigDecimal`): JSON serializa number JS como número; backend aceita como `BigDecimal`. Compatível.
+- **Mock de `fecharMes` nos testes**: `vi.mock('../../api/folha', ...)` — o módulo é mockado inteiramente para não fazer fetch real. O teste de loading mantém a promise pendente durante a verificação e resolve ao final para evitar act() warning.
+- **Alerta negativo: sem bloqueio de confirmação**: o usuário pode confirmar mesmo com valor negativo (o backend é fonte de verdade). O badge serve como aviso visual.
+
+---
+
+## Decisões pendentes (esperando humano)
+
+Nenhuma — tarefa fechada.
+
+---
+
+## Próximos passos / observações pro próximo
+
+Sprint 03 de front está completa: FE-015 + FE-016 + FE-017 todas em integration.
+O PR #94 (`integration/03-folha-pagamento` → `develop`) aguarda revisão humana.
+
+---
+
+## Padrões técnicos
+
+**Cálculo client-side + POST de confirmação:**
+O preview é calculado localmente sem roundtrip: `valorFinal = salarioBase - totalVales - totalParcelas + ajuste`. Isso evita delay visual a cada keystroke no campo ajuste. O POST final é a única chamada ao backend. O resultado do POST (`observacao`, `valor`) pode divergir levemente do preview se houver mudanças nos dados entre o carregamento da tela e o fechamento — aceitável por design (informado no tooltip).
+
+**Mocking de módulo com `vi.mock` + `vi.mocked`:**
+Padrão Vitest para isolar chamadas de API: `vi.mock('../../api/folha', () => ({ fecharMes: vi.fn() }))` + `const fecharMesMock = vi.mocked(fecharMes)`. Permite controlar o retorno por teste sem afetar outros módulos.
+
+---
+
+## Arquivos criados/modificados
+
+- `frontend/src/api/folha.ts` (modificado: `fecharMes()` adicionada)
+- `frontend/src/components/folha/ModalFechamento.tsx` (modificado: implementação completa substituiu stub)
+- `frontend/src/components/folha/ModalFechamento.test.tsx` (novo — 5 testes)
+- `frontend/src/paginas/folha/FolhaFuncionarioPage.tsx` (modificado: toast de sucesso + atualização de comentário)

--- a/frontend/src/api/folha.ts
+++ b/frontend/src/api/folha.ts
@@ -78,4 +78,20 @@ export async function listarFechamentos(funcionarioId: number): Promise<Fechamen
   return client.get<Fechamento[]>(`/api/funcionarios/${funcionarioId}/fechamentos`)
 }
 
-// fecharMes() será adicionado por FE-017 (POST /api/funcionarios/{id}/fechamentos)
+// ── Fechar mês (FE-017) ───────────────────────────────────────────────────────
+
+/**
+ * POST /api/funcionarios/{id}/fechamentos
+ * Gera o Pedido FOLHA com o valor líquido calculado pelo backend.
+ * @param ajuste positivo = bônus; negativo = desconto extra. Padrão: 0.
+ */
+export async function fecharMes(
+  funcionarioId: number,
+  mes: string,
+  ajuste: number,
+): Promise<Fechamento> {
+  return client.post<Fechamento>(`/api/funcionarios/${funcionarioId}/fechamentos`, {
+    mes,
+    ajuste,
+  })
+}

--- a/frontend/src/components/folha/ModalFechamento.test.tsx
+++ b/frontend/src/components/folha/ModalFechamento.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * ModalFechamento.test.tsx — testes do modal de fechamento mensal (FE-017).
+ *
+ * Testa o cálculo em tempo real, alerta de valor negativo, loading state e fechamento sem render.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { ModalFechamento } from './ModalFechamento'
+import type { Adiantamento, Fechamento } from '../../types/folha'
+
+// Mock da API de fecharMes
+vi.mock('../../api/folha', () => ({
+  fecharMes: vi.fn(),
+}))
+
+import { fecharMes } from '../../api/folha'
+const fecharMesMock = vi.mocked(fecharMes)
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const adiantamentoA: Adiantamento = {
+  id: 1,
+  funcionarioId: 10,
+  descricao: 'Óculos',
+  valorTotal: 600,
+  valorParcela: 200,
+  numParcelas: 3,
+  parcelasPagas: 0,
+  parcelasRestantes: 3,
+  dataInicio: '2026-05-01',
+  ativo: true,
+  criadoEm: '2026-05-01T09:00:00',
+}
+
+const defaultProps = {
+  open: true,
+  funcionarioId: 10,
+  mes: '2026-06',
+  salarioBase: 2000,
+  totalVales: 150,
+  listaAdiantamentosAtivos: [adiantamentoA],
+  onClose: vi.fn(),
+  onConfirmado: vi.fn(),
+}
+
+// ── Testes ────────────────────────────────────────────────────────────────────
+
+describe('ModalFechamento — não renderiza quando fechado', () => {
+  it('não renderiza o modal quando open=false', () => {
+    render(<ModalFechamento {...defaultProps} open={false} />)
+    expect(screen.queryByTestId('modal-fechamento')).not.toBeInTheDocument()
+  })
+})
+
+describe('ModalFechamento — cálculo em tempo real', () => {
+  it('exibe o valor final correto: salário(2000) - vales(150) - parcelas(200) = 1650', () => {
+    render(<ModalFechamento {...defaultProps} />)
+    // valorFinal = 2000 - 150 - 200 + 0 = 1650
+    const valorFinal = screen.getByTestId('valor-final')
+    expect(valorFinal).toHaveTextContent('1.650')
+  })
+
+  it('campo ajuste atualiza o valor final em tempo real', () => {
+    render(<ModalFechamento {...defaultProps} />)
+    const inputAjuste = screen.getByTestId('input-ajuste')
+
+    // Adicionar bônus de 100
+    fireEvent.change(inputAjuste, { target: { value: '100' } })
+
+    // valorFinal = 2000 - 150 - 200 + 100 = 1750
+    expect(screen.getByTestId('valor-final')).toHaveTextContent('1.750')
+  })
+
+  it('exibe alerta vermelho quando valor final é negativo', () => {
+    render(
+      <ModalFechamento
+        {...defaultProps}
+        salarioBase={200}    // salário baixo para forçar negativo
+        totalVales={300}
+      />,
+    )
+    // valorFinal = 200 - 300 - 200 + 0 = -300
+    expect(screen.getByTestId('alerta-negativo')).toBeInTheDocument()
+  })
+})
+
+describe('ModalFechamento — confirmação', () => {
+  it('botão "Confirmar fechamento" fica desabilitado durante o POST (loading)', async () => {
+    let resolverFechamento!: (v: Fechamento) => void
+    fecharMesMock.mockReturnValue(
+      new Promise<Fechamento>((resolve) => {
+        resolverFechamento = resolve
+      }),
+    )
+
+    render(<ModalFechamento {...defaultProps} />)
+    const btn = screen.getByTestId('btn-confirmar')
+    fireEvent.click(btn)
+
+    // Durante o loading o botão fica disabled
+    await waitFor(() => {
+      expect(btn).toBeDisabled()
+      expect(btn).toHaveTextContent('Fechando…')
+    })
+
+    // Resolver a promise para não deixar a promise pendente
+    const fechamentoFake: Fechamento = {
+      id: 99,
+      funcionarioId: 10,
+      valor: 1650,
+      status: 'PENDENTE',
+      observacao: null,
+      mesReferencia: '2026-06-01',
+      dataCriacao: '2026-06-04T12:00:00',
+    }
+    resolverFechamento(fechamentoFake)
+    await waitFor(() => expect(defaultProps.onConfirmado).toHaveBeenCalled())
+  })
+})

--- a/frontend/src/components/folha/ModalFechamento.tsx
+++ b/frontend/src/components/folha/ModalFechamento.tsx
@@ -1,16 +1,20 @@
 /**
- * ModalFechamento — STUB para FE-017.
+ * ModalFechamento — modal de fechamento mensal com cálculo em tempo real (FE-017).
  *
- * Interface de props estabelecida por FE-016 para contratos com FolhaFuncionarioPage.
- * FE-017 substitui este stub pela implementação completa com:
- *   - preview em tempo real (salário - vales - parcelas adiantamentos + ajuste)
- *   - alerta para valor negativo
- *   - POST /api/funcionarios/{id}/fechamentos
- *   - toast de confirmação
+ * Recebe os dados carregados pela FolhaFuncionarioPage via props:
+ *   salarioBase, totalVales, listaAdiantamentosAtivos.
  *
- * Props definidas aqui são o contrato que FE-017 deve seguir sem alteração.
+ * Calcula localmente: valorFinal = salarioBase - totalVales - totalParcelas + ajuste.
+ * Sem roundtrip para preview — só o POST final vai ao backend.
+ *
+ * Após sucesso: chama onConfirmado(fechamento) → FolhaFuncionarioPage invalida o cache.
+ * Erro 409 (mês já fechado): mensagem clara.
  */
 
+import { useState } from 'react'
+import { formatarMoeda } from '../../lib/formato'
+import { fecharMes } from '../../api/folha'
+import { ApiError } from '../../api/client'
 import type { Adiantamento, Fechamento } from '../../types/folha'
 
 export interface ModalFechamentoProps {
@@ -24,8 +28,45 @@ export interface ModalFechamentoProps {
   onConfirmado: (fechamento: Fechamento) => void
 }
 
-export function ModalFechamento({ open, mes, onClose }: ModalFechamentoProps) {
+export function ModalFechamento({
+  open,
+  funcionarioId,
+  mes,
+  salarioBase,
+  totalVales,
+  listaAdiantamentosAtivos,
+  onClose,
+  onConfirmado,
+}: ModalFechamentoProps) {
+  const [ajuste, setAjuste] = useState('0')
+  const [salvando, setSalvando] = useState(false)
+  const [erro, setErro] = useState<string | null>(null)
+
   if (!open) return null
+
+  const totalParcelas = listaAdiantamentosAtivos.reduce(
+    (sum, adt) => sum + adt.valorParcela,
+    0,
+  )
+  const ajusteNum = parseFloat(ajuste) || 0
+  const valorFinal = salarioBase - totalVales - totalParcelas + ajusteNum
+  const negativo = valorFinal < 0
+
+  async function handleConfirmar() {
+    setSalvando(true)
+    setErro(null)
+    try {
+      const fechamento = await fecharMes(funcionarioId, mes, ajusteNum)
+      onConfirmado(fechamento)
+    } catch (e) {
+      if (e instanceof ApiError && e.codigo === 409) {
+        setErro('Mês já fechado. Recarregue a página.')
+      } else {
+        setErro('Erro ao fechar mês. Tente novamente.')
+      }
+      setSalvando(false)
+    }
+  }
 
   return (
     <div
@@ -33,20 +74,105 @@ export function ModalFechamento({ open, mes, onClose }: ModalFechamentoProps) {
       aria-modal="true"
       aria-label={`Fechar mês ${mes}`}
       className="fixed inset-0 z-50 flex items-end justify-center bg-black/50"
+      data-testid="modal-fechamento"
     >
-      <div className="bg-white rounded-t-2xl w-full max-w-md p-6 pb-8">
-        <p className="text-sm font-semibold text-zinc-800 mb-2">
-          Fechar mês {mes}
-        </p>
-        <p className="text-xs text-zinc-400 mb-6">
-          Implementação completa disponível na task FE-017.
-        </p>
-        <button
-          onClick={onClose}
-          className="w-full text-sm text-zinc-500 border border-zinc-200 rounded-xl py-2 hover:bg-zinc-50 transition-colors"
-        >
-          Fechar
-        </button>
+      <div className="bg-white rounded-t-2xl w-full max-w-md p-6 pb-10 space-y-5">
+        {/* Título */}
+        <div>
+          <h2 className="text-base font-bold text-zinc-900">Fechar mês {mes}</h2>
+          <p className="text-xs text-zinc-400 mt-0.5">Preview do cálculo baseado nos dados carregados.</p>
+        </div>
+
+        {/* Breakdown */}
+        <div className="space-y-2">
+          <div className="flex justify-between text-sm">
+            <span className="text-zinc-600">Salário base</span>
+            <span className="font-medium text-zinc-800">{formatarMoeda(salarioBase)}</span>
+          </div>
+
+          <div className="flex justify-between text-sm">
+            <span className="text-zinc-600">
+              Vales ({listaAdiantamentosAtivos.length === 0 && totalVales === 0 ? '0' : '−'})
+            </span>
+            <span className="font-medium text-red-600">
+              − {formatarMoeda(totalVales)}
+            </span>
+          </div>
+
+          <div className="flex justify-between text-sm">
+            <span className="text-zinc-600">
+              Parcelas adiantamentos ({listaAdiantamentosAtivos.length})
+            </span>
+            <span className="font-medium text-red-600">
+              − {formatarMoeda(totalParcelas)}
+            </span>
+          </div>
+
+          {/* Ajuste */}
+          <div className="flex items-center justify-between gap-3">
+            <label htmlFor="modal-ajuste" className="text-sm text-zinc-600 shrink-0">
+              Ajuste (bônus/desconto)
+            </label>
+            <input
+              id="modal-ajuste"
+              type="number"
+              step="0.01"
+              value={ajuste}
+              onChange={(e) => setAjuste(e.target.value)}
+              className="w-28 text-right rounded-lg border border-zinc-200 px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              aria-label="Ajuste"
+              data-testid="input-ajuste"
+            />
+          </div>
+
+          <div className="border-t border-zinc-100 pt-2 flex justify-between text-sm font-semibold">
+            <span className="text-zinc-700">Valor final</span>
+            <span
+              className={negativo ? 'text-red-600' : 'text-emerald-600'}
+              data-testid="valor-final"
+            >
+              {formatarMoeda(valorFinal)}
+            </span>
+          </div>
+        </div>
+
+        {/* Alerta valor negativo */}
+        {negativo && (
+          <div
+            className="bg-red-50 border border-red-200 rounded-xl px-4 py-2"
+            data-testid="alerta-negativo"
+          >
+            <p className="text-xs text-red-700 font-medium">
+              ⚠ Valor negativo — verificar vales e adiantamentos antes de confirmar.
+            </p>
+          </div>
+        )}
+
+        {/* Erro */}
+        {erro && (
+          <p className="text-xs text-red-600" data-testid="modal-erro">
+            {erro}
+          </p>
+        )}
+
+        {/* Ações */}
+        <div className="flex gap-3">
+          <button
+            onClick={onClose}
+            disabled={salvando}
+            className="flex-1 text-sm text-zinc-600 border border-zinc-200 rounded-xl py-2.5 hover:bg-zinc-50 disabled:opacity-50 transition-colors"
+          >
+            Cancelar
+          </button>
+          <button
+            onClick={handleConfirmar}
+            disabled={salvando}
+            className="flex-1 bg-emerald-600 text-white text-sm font-semibold py-2.5 rounded-xl hover:bg-emerald-700 disabled:opacity-50 transition-colors"
+            data-testid="btn-confirmar"
+          >
+            {salvando ? 'Fechando…' : 'Confirmar fechamento'}
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/frontend/src/paginas/folha/FolhaFuncionarioPage.tsx
+++ b/frontend/src/paginas/folha/FolhaFuncionarioPage.tsx
@@ -1,9 +1,10 @@
 /**
- * FolhaFuncionarioPage — tela de operação do funcionário (FE-016).
+ * FolhaFuncionarioPage — tela de operação do funcionário (FE-016 + FE-017).
  *
  * Rota: /folha/funcionarios/:id
  * Exibe: vales do mês, adiantamentos ativos, fechamentos anteriores.
  * Botão "Fechar mês" aparece somente se o mês selecionado ainda não foi fechado.
+ * Após confirmação do fechamento (FE-017): exibe banner de sucesso + invalida cache.
  */
 
 import { useState } from 'react'
@@ -31,6 +32,7 @@ export function FolhaFuncionarioPage() {
 
   const [mesSelecionado, setMesSelecionado] = useState(mesCorrente)
   const [modalAberto, setModalAberto] = useState(false)
+  const [toastSucesso, setToastSucesso] = useState<string | null>(null)
 
   const {
     funcionario,
@@ -48,8 +50,8 @@ export function FolhaFuncionarioPage() {
   function handleFecharMesConfirmado(fechamento: Fechamento) {
     setModalAberto(false)
     invalidarPosFechamento()
-    // FE-017 pode adicionar toast aqui
-    void fechamento // suppress unused warning
+    setToastSucesso(`Mês ${fechamento.mesReferencia.slice(0, 7)} fechado — ${formatarMoeda(fechamento.valor)}`)
+    setTimeout(() => setToastSucesso(null), 4000)
   }
 
   // Label do mês para o botão
@@ -147,6 +149,17 @@ export function FolhaFuncionarioPage() {
         {/* Seção Fechamentos */}
         <FechamentosSection fechamentos={fechamentos} />
       </main>
+
+      {/* Toast de sucesso (FE-017) */}
+      {toastSucesso && (
+        <div
+          className="fixed bottom-6 left-1/2 -translate-x-1/2 bg-emerald-600 text-white text-sm font-medium px-5 py-3 rounded-full shadow-lg z-50"
+          role="status"
+          data-testid="toast-sucesso"
+        >
+          ✓ {toastSucesso}
+        </div>
+      )}
 
       {/* Modal Fechamento (FE-017) */}
       {funcionario && (


### PR DESCRIPTION
## Summary

- Implementa `ModalFechamento` completo substituindo o stub criado em FE-016
- Cálculo em tempo real no front: `salárioBase - totalVales - totalParcelas + ajuste` sem roundtrip
- Campo `ajuste` (default 0) atualiza valor final imediatamente; alerta vermelho para valor negativo
- POST via `fecharMes()` adicionada em `folha.ts`; erro 409 → "Mês já fechado"
- Toast de sucesso em `FolhaFuncionarioPage` após confirmação (desaparece em 4s)
- 5 novos testes: sem render quando closed, preview correto, ajuste atualiza, alerta negativo, loading state

## Test plan

- [x] `npm test` — 83/83 verde (5 novos)
- [x] `npm run lint` — limpo
- [x] `npm run build` — sem erros TS
- [x] Branch a partir de `integration/03-folha-pagamento` (inclui FE-016)
- [x] Território: apenas `frontend/` + status reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)