### PR TITLE
fix(FE-017): corrige label de vales no ModalFechamento

### DIFF
--- a/frontend/src/components/folha/ModalFechamento.tsx
+++ b/frontend/src/components/folha/ModalFechamento.tsx
@@ -92,7 +92,7 @@ export function ModalFechamento({
 
           <div className="flex justify-between text-sm">
             <span className="text-zinc-600">
-              Vales ({listaAdiantamentosAtivos.length === 0 && totalVales === 0 ? '0' : '−'})
+              Vales ({totalVales === 0 ? '0' : '−'})
             </span>
             <span className="font-medium text-red-600">
               − {formatarMoeda(totalVales)}


### PR DESCRIPTION
## Fix

Bug cosmético identificado pelo Reviewer em FE-017.

**Problema:** `ModalFechamento.tsx:95` usava `listaAdiantamentosAtivos.length === 0 && totalVales === 0` para determinar o label da linha de vales. A condição estava errada — `listaAdiantamentosAtivos` é a lista de adiantamentos, não de vales. Quando o funcionário tem vales mas não tem adiantamentos ativos, o label exibia `Vales (0)` mesmo com `totalVales > 0`.

**Fix:** Simplificado para `totalVales === 0 ? '0' : '−'` — usa diretamente o valor correto.

## Test plan

- [x] `npm test` — 83/83 verde
- [x] `npm run build` — sem erros
- [x] `npm run lint` — limpo
🤖 Generated with [Claude Code](https://claude.com/claude-code)