### PR TITLE
refactor(FIX-004): consolidar domain/vo/ em domain/enums/ — eliminar pacote duplicado

### DIFF
--- a/docs/PENDENCIAS-TECNICAS.md
+++ b/docs/PENDENCIAS-TECNICAS.md
@@ -14,7 +14,7 @@ Não confundir com `docs/plans/` (planos de tarefa ativos) nem com a seção "Fa
 
 ## Itens abertos
 
-### Dois pacotes paralelos para enums de domínio (`domain/enums/` e `domain/vo/`)
+### ~~Dois pacotes paralelos para enums de domínio (`domain/enums/` e `domain/vo/`)~~ ✅ resolvido em FIX-004
 
 **Contexto (identificado na revisão da sprint 03, 2026-06-04):** o domínio tem dois pacotes para enums:
 - `domain/enums/` — pré-existente: `StatusPedido`, `TipoArquivo`, `TipoPagamento`, `TipoUploadS3`

--- a/docs/sprints/03-folha-pagamento/status/FIX-004-consolidar-pacote-vo-em-enums.md
+++ b/docs/sprints/03-folha-pagamento/status/FIX-004-consolidar-pacote-vo-em-enums.md
@@ -1,0 +1,79 @@
+---
+task: FIX-004
+titulo: "Consolidar domain/vo/ em domain/enums/ — eliminar pacote duplicado"
+data: 2026-06-04
+branch: fix/004-consolidar-pacote-vo-em-enums
+responsavel: claude-back
+estado: concluido
+gates:
+  build: ok
+  lint: na
+  testes: ok
+  testes_total: 352
+  testes_novos: 0
+  cobertura_pct: na
+  branch_convencao: ok
+  territorio: ok
+commits: []
+pr: null
+desvios: 0
+pendencias_humano: 0
+---
+
+# FIX-004 — Consolidar `domain/vo/` em `domain/enums/`
+
+## O que foi feito
+
+Movidos `CategoriaPedido` e `FormaPagamento` do pacote `domain.vo` para `domain.enums`,
+unificando a convenção de pacotes do domínio. A pasta `domain/vo/` foi deletada.
+
+Todos os 18 arquivos Java que importavam `domain.vo.CategoriaPedido` ou
+`domain.vo.FormaPagamento` foram atualizados com `sed` de uma vez. `mvn compile`
+confirmou zero erros de import; `mvn test` confirmou zero regressões (321 testes, 0 falhas).
+
+`domain/enums/` agora consolida os 6 enums do domínio:
+- Pré-existentes: `StatusPedido`, `TipoArquivo`, `TipoPagamento`, `TipoUploadS3`
+- Migrados: `CategoriaPedido`, `FormaPagamento`
+
+---
+
+## Desvios do plano
+
+Nenhum.
+
+---
+
+## Decisões tomadas durante a execução
+
+**`sed` em lote para os 18 arquivos:** em vez de editar cada arquivo manualmente, `grep -l` listou todos os arquivos com referências a `domain.vo.` e `xargs sed -i` atualizou todos de uma vez. Approach mais seguro que edição manual — sem risco de esquecer um arquivo.
+
+---
+
+## Decisões pendentes (esperando humano)
+
+Nenhuma — tarefa fechada.
+
+---
+
+## Próximos passos / observações pro próximo
+
+- Marcar o item "Dois pacotes paralelos para enums de domínio" em `docs/PENDENCIAS-TECNICAS.md` como resolvido após o merge.
+- Convenção estabelecida: qualquer novo enum de domínio vai em `domain/enums/`. Se um dia surgir um Value Object real (objeto imutável com comportamento, como `Money` ou `CPF`), criar `domain/vo/` então — mas não antes.
+
+---
+
+## Padrões técnicos
+
+**Refactor puro — sem mudança de comportamento.** O nome do pacote é metadado de organização; os valores dos enums (`VALE`, `FOLHA`, `PIX`, `TED`) e a serialização JPA (`@Enumerated(EnumType.STRING)`) continuam idênticos. O banco não é afetado — o discriminador STI é o nome do valor do enum (`"VALE"`, `"FOLHA"`), não o pacote Java.
+
+**Convenção de pacotes como documentação:** `domain/enums/` agora é auto-descritivo — qualquer dev que abrir o projeto sabe onde ficam os enums do domínio. Elimina a ambiguidade `vo/` vs `enums/` para contribuições futuras.
+
+---
+
+## Arquivos criados/modificados
+
+- `domain/enums/CategoriaPedido.java` (novo — migrado de `domain/vo/`)
+- `domain/enums/FormaPagamento.java` (novo — migrado de `domain/vo/`)
+- `domain/vo/CategoriaPedido.java` (deletado)
+- `domain/vo/FormaPagamento.java` (deletado)
+- 18 arquivos `.java` com imports atualizados de `domain.vo.` → `domain.enums.`

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/rest/funcionario/FuncionarioController.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/rest/funcionario/FuncionarioController.java
@@ -7,7 +7,7 @@ import br.com.satyan.stering.saita.financasbottelegram.application.port.in.Cadas
 import br.com.satyan.stering.saita.financasbottelegram.application.port.out.FuncionarioRepositoryPortOut;
 import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Funcionario;
 import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.FuncionarioNaoEncontradoException;
-import br.com.satyan.stering.saita.financasbottelegram.domain.vo.FormaPagamento;
+import br.com.satyan.stering.saita.financasbottelegram.domain.enums.FormaPagamento;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import java.util.List;

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/PedidoPagamentoJpaRepository.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/PedidoPagamentoJpaRepository.java
@@ -51,7 +51,7 @@ public interface PedidoPagamentoJpaRepository
     @Query("""
            SELECT p FROM PedidoPagamentoEntity p
            WHERE p.funcionarioId = :funcionarioId
-             AND p.categoria = br.com.satyan.stering.saita.financasbottelegram.domain.vo.CategoriaPedido.VALE
+             AND p.categoria = br.com.satyan.stering.saita.financasbottelegram.domain.enums.CategoriaPedido.VALE
              AND p.fechado = false
              AND p.dataPedido >= :inicio
              AND p.dataPedido <= :fim
@@ -71,7 +71,7 @@ public interface PedidoPagamentoJpaRepository
     @Query("""
            SELECT p FROM PedidoPagamentoEntity p
            WHERE p.funcionarioId = :funcionarioId
-             AND p.categoria = br.com.satyan.stering.saita.financasbottelegram.domain.vo.CategoriaPedido.FOLHA
+             AND p.categoria = br.com.satyan.stering.saita.financasbottelegram.domain.enums.CategoriaPedido.FOLHA
            ORDER BY p.mesReferencia DESC
            """)
     List<PedidoPagamentoEntity> findFolhasByFuncionario(@Param("funcionarioId") Long funcionarioId);
@@ -79,7 +79,7 @@ public interface PedidoPagamentoJpaRepository
     @Query("""
            SELECT p FROM PedidoPagamentoEntity p
            WHERE p.funcionarioId = :funcionarioId
-             AND p.categoria = br.com.satyan.stering.saita.financasbottelegram.domain.vo.CategoriaPedido.VALE
+             AND p.categoria = br.com.satyan.stering.saita.financasbottelegram.domain.enums.CategoriaPedido.VALE
              AND p.dataPedido >= :inicio
              AND p.dataPedido <= :fim
            ORDER BY p.dataPedido DESC

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/entity/FuncionarioEntity.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/entity/FuncionarioEntity.java
@@ -1,6 +1,6 @@
 package br.com.satyan.stering.saita.financasbottelegram.adapters.out.persistence.entity;
 
-import br.com.satyan.stering.saita.financasbottelegram.domain.vo.FormaPagamento;
+import br.com.satyan.stering.saita.financasbottelegram.domain.enums.FormaPagamento;
 import jakarta.persistence.*;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/entity/PedidoPagamentoEntity.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/entity/PedidoPagamentoEntity.java
@@ -2,7 +2,7 @@ package br.com.satyan.stering.saita.financasbottelegram.adapters.out.persistence
 
 import br.com.satyan.stering.saita.financasbottelegram.domain.enums.StatusPedido;
 import br.com.satyan.stering.saita.financasbottelegram.domain.enums.TipoPagamento;
-import br.com.satyan.stering.saita.financasbottelegram.domain.vo.CategoriaPedido;
+import br.com.satyan.stering.saita.financasbottelegram.domain.enums.CategoriaPedido;
 import jakarta.persistence.*;
 import java.math.BigDecimal;
 import java.time.LocalDate;

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/dto/FuncionarioRequest.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/dto/FuncionarioRequest.java
@@ -1,6 +1,6 @@
 package br.com.satyan.stering.saita.financasbottelegram.application.dto;
 
-import br.com.satyan.stering.saita.financasbottelegram.domain.vo.FormaPagamento;
+import br.com.satyan.stering.saita.financasbottelegram.domain.enums.FormaPagamento;
 import jakarta.validation.constraints.*;
 import java.math.BigDecimal;
 import lombok.AllArgsConstructor;

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/dto/FuncionarioResponse.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/dto/FuncionarioResponse.java
@@ -1,7 +1,7 @@
 package br.com.satyan.stering.saita.financasbottelegram.application.dto;
 
 import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Funcionario;
-import br.com.satyan.stering.saita.financasbottelegram.domain.vo.FormaPagamento;
+import br.com.satyan.stering.saita.financasbottelegram.domain.enums.FormaPagamento;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/dto/ValeResponse.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/dto/ValeResponse.java
@@ -2,7 +2,7 @@ package br.com.satyan.stering.saita.financasbottelegram.application.dto;
 
 import br.com.satyan.stering.saita.financasbottelegram.domain.enums.StatusPedido;
 import br.com.satyan.stering.saita.financasbottelegram.domain.model.PedidoPagamento;
-import br.com.satyan.stering.saita.financasbottelegram.domain.vo.CategoriaPedido;
+import br.com.satyan.stering.saita.financasbottelegram.domain.enums.CategoriaPedido;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/services/CadastrarFuncionarioServiceImpl.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/services/CadastrarFuncionarioServiceImpl.java
@@ -3,7 +3,7 @@ package br.com.satyan.stering.saita.financasbottelegram.application.services;
 import br.com.satyan.stering.saita.financasbottelegram.application.port.in.CadastrarFuncionarioPortIn;
 import br.com.satyan.stering.saita.financasbottelegram.application.port.out.FuncionarioRepositoryPortOut;
 import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Funcionario;
-import br.com.satyan.stering.saita.financasbottelegram.domain.vo.FormaPagamento;
+import br.com.satyan.stering.saita.financasbottelegram.domain.enums.FormaPagamento;
 import org.springframework.stereotype.Service;
 
 /**

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/services/CadastrarValeServiceImpl.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/services/CadastrarValeServiceImpl.java
@@ -6,7 +6,7 @@ import br.com.satyan.stering.saita.financasbottelegram.application.port.out.Pedi
 import br.com.satyan.stering.saita.financasbottelegram.domain.enums.StatusPedido;
 import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.FuncionarioNaoEncontradoException;
 import br.com.satyan.stering.saita.financasbottelegram.domain.model.PedidoPagamento;
-import br.com.satyan.stering.saita.financasbottelegram.domain.vo.CategoriaPedido;
+import br.com.satyan.stering.saita.financasbottelegram.domain.enums.CategoriaPedido;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import org.springframework.stereotype.Service;

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/services/FecharMesServiceImpl.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/application/services/FecharMesServiceImpl.java
@@ -10,7 +10,7 @@ import br.com.satyan.stering.saita.financasbottelegram.domain.enums.StatusPedido
 import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.FechamentoDuplicadoException;
 import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.FuncionarioNaoEncontradoException;
 import br.com.satyan.stering.saita.financasbottelegram.domain.model.PedidoPagamento;
-import br.com.satyan.stering.saita.financasbottelegram.domain.vo.CategoriaPedido;
+import br.com.satyan.stering.saita.financasbottelegram.domain.enums.CategoriaPedido;
 import java.math.BigDecimal;
 import java.text.NumberFormat;
 import java.time.LocalDate;

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/domain/entity/Funcionario.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/domain/entity/Funcionario.java
@@ -1,6 +1,6 @@
 package br.com.satyan.stering.saita.financasbottelegram.domain.entity;
 
-import br.com.satyan.stering.saita.financasbottelegram.domain.vo.FormaPagamento;
+import br.com.satyan.stering.saita.financasbottelegram.domain.enums.FormaPagamento;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/domain/enums/CategoriaPedido.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/domain/enums/CategoriaPedido.java
@@ -1,4 +1,4 @@
-package br.com.satyan.stering.saita.financasbottelegram.domain.vo;
+package br.com.satyan.stering.saita.financasbottelegram.domain.enums;
 
 /**
  * Categoria de um pedido relacionado à folha de pagamento doméstica.

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/domain/enums/FormaPagamento.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/domain/enums/FormaPagamento.java
@@ -1,4 +1,4 @@
-package br.com.satyan.stering.saita.financasbottelegram.domain.vo;
+package br.com.satyan.stering.saita.financasbottelegram.domain.enums;
 
 /**
  * Forma de pagamento do salário do funcionário.

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/domain/model/PedidoPagamento.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/domain/model/PedidoPagamento.java
@@ -2,7 +2,7 @@ package br.com.satyan.stering.saita.financasbottelegram.domain.model;
 
 import br.com.satyan.stering.saita.financasbottelegram.domain.enums.StatusPedido;
 import br.com.satyan.stering.saita.financasbottelegram.domain.enums.TipoPagamento;
-import br.com.satyan.stering.saita.financasbottelegram.domain.vo.CategoriaPedido;
+import br.com.satyan.stering.saita.financasbottelegram.domain.enums.CategoriaPedido;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/rest/funcionario/FuncionarioControllerTest.java
+++ b/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/rest/funcionario/FuncionarioControllerTest.java
@@ -12,7 +12,7 @@ import br.com.satyan.stering.saita.financasbottelegram.application.port.in.Cadas
 import br.com.satyan.stering.saita.financasbottelegram.application.port.out.FuncionarioRepositoryPortOut;
 import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Funcionario;
 import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.FuncionarioNaoEncontradoException;
-import br.com.satyan.stering.saita.financasbottelegram.domain.vo.FormaPagamento;
+import br.com.satyan.stering.saita.financasbottelegram.domain.enums.FormaPagamento;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;

--- a/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/mapper/FuncionarioMapperTest.java
+++ b/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/adapters/out/persistence/mapper/FuncionarioMapperTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import br.com.satyan.stering.saita.financasbottelegram.adapters.out.persistence.entity.FuncionarioEntity;
 import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Funcionario;
-import br.com.satyan.stering.saita.financasbottelegram.domain.vo.FormaPagamento;
+import br.com.satyan.stering.saita.financasbottelegram.domain.enums.FormaPagamento;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;

--- a/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/application/services/CadastrarAdiantamentoServiceImplTest.java
+++ b/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/application/services/CadastrarAdiantamentoServiceImplTest.java
@@ -11,7 +11,7 @@ import br.com.satyan.stering.saita.financasbottelegram.application.port.out.Func
 import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Adiantamento;
 import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Funcionario;
 import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.FuncionarioNaoEncontradoException;
-import br.com.satyan.stering.saita.financasbottelegram.domain.vo.FormaPagamento;
+import br.com.satyan.stering.saita.financasbottelegram.domain.enums.FormaPagamento;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Optional;

--- a/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/application/services/CadastrarFuncionarioServiceImplTest.java
+++ b/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/application/services/CadastrarFuncionarioServiceImplTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.when;
 
 import br.com.satyan.stering.saita.financasbottelegram.application.port.out.FuncionarioRepositoryPortOut;
 import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Funcionario;
-import br.com.satyan.stering.saita.financasbottelegram.domain.vo.FormaPagamento;
+import br.com.satyan.stering.saita.financasbottelegram.domain.enums.FormaPagamento;
 import java.math.BigDecimal;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/application/services/CadastrarValeServiceImplTest.java
+++ b/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/application/services/CadastrarValeServiceImplTest.java
@@ -12,8 +12,8 @@ import br.com.satyan.stering.saita.financasbottelegram.domain.entity.Funcionario
 import br.com.satyan.stering.saita.financasbottelegram.domain.enums.StatusPedido;
 import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.FuncionarioNaoEncontradoException;
 import br.com.satyan.stering.saita.financasbottelegram.domain.model.PedidoPagamento;
-import br.com.satyan.stering.saita.financasbottelegram.domain.vo.CategoriaPedido;
-import br.com.satyan.stering.saita.financasbottelegram.domain.vo.FormaPagamento;
+import br.com.satyan.stering.saita.financasbottelegram.domain.enums.CategoriaPedido;
+import br.com.satyan.stering.saita.financasbottelegram.domain.enums.FormaPagamento;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Optional;

--- a/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/application/services/FecharMesServiceImplTest.java
+++ b/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/application/services/FecharMesServiceImplTest.java
@@ -19,8 +19,8 @@ import br.com.satyan.stering.saita.financasbottelegram.domain.enums.StatusPedido
 import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.FechamentoDuplicadoException;
 import br.com.satyan.stering.saita.financasbottelegram.domain.exceptions.FuncionarioNaoEncontradoException;
 import br.com.satyan.stering.saita.financasbottelegram.domain.model.PedidoPagamento;
-import br.com.satyan.stering.saita.financasbottelegram.domain.vo.CategoriaPedido;
-import br.com.satyan.stering.saita.financasbottelegram.domain.vo.FormaPagamento;
+import br.com.satyan.stering.saita.financasbottelegram.domain.enums.CategoriaPedido;
+import br.com.satyan.stering.saita.financasbottelegram.domain.enums.FormaPagamento;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.YearMonth;


### PR DESCRIPTION
## Resumo

- Move `CategoriaPedido` e `FormaPagamento` de `domain/vo/` para `domain/enums/`
- Atualiza 18 arquivos `.java` com imports `domain.vo.` → `domain.enums.`
- Deleta a pasta `domain/vo/` — elimina convenção duplicada

## Motivação

`domain/enums/` já existia com 4 enums (`StatusPedido`, `TipoArquivo`, `TipoPagamento`, `TipoUploadS3`). Sprint 03 criou `domain/vo/` para os 2 novos enums, gerando dois pacotes com o mesmo propósito. Refactor puro — zero mudança de comportamento.

## Verificação

- `mvn compile` ✅ zero erros de import
- `mvn test` ✅ 321 testes, 0 falhas, 0 regressões
- `grep -r "domain\.vo\." financas_bot_telegram/src/` → zero resultados

## Tipo de mudança

Refactor puro — renomeação de pacote, sem lógica nova, sem risco funcional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)