### PR TITLE
fix(FIX-005): padronizar /api/funcionarios → /api/v1/funcionarios + JWT allowlist (back)

### DIFF
--- a/docs/sprints/03-folha-pagamento/status/FIX-005-back-padronizar-api-v1.md
+++ b/docs/sprints/03-folha-pagamento/status/FIX-005-back-padronizar-api-v1.md
@@ -1,0 +1,91 @@
+---
+task: FIX-005
+titulo: "Padronizar /api/funcionarios/** → /api/v1/funcionarios/** + proteger com JWT (back)"
+data: 2026-06-04
+branch: fix/005-padronizar-api-v1
+responsavel: claude-back
+estado: concluido
+gates:
+  build: ok
+  lint: na
+  testes: ok
+  testes_total: 352
+  testes_novos: 0
+  cobertura_pct: na
+  branch_convencao: ok
+  territorio: ok
+commits: []
+pr: null
+desvios: 0
+pendencias_humano: 0
+---
+
+# FIX-005 (back) — Padronizar `/api/funcionarios/**` → `/api/v1/funcionarios/**` + JWT allowlist
+
+## O que foi feito
+
+**Fix primário — padronização de URL:**
+`FolhaController` e `FuncionarioController` agora mapeiam `@RequestMapping("/api/v1/funcionarios")`. Os 11 endpoints que estavam sob `/api/funcionarios/**` foram movidos para `/api/v1/funcionarios/**`, eliminando o prefixo fora do padrão do projeto. Javadocs de ambos os controllers atualizados.
+
+**Fix secundário — `shouldNotFilter()` com allowlist explícita:**
+`JwtAuthenticationFilter.shouldNotFilter()` foi refatorado de lógica negativa (`!path.startsWith("/api/v1/")`) para allowlist positiva. A nova lógica lista explicitamente os paths públicos (`/api/v1/auth/exchange`, `/webhook`, `/actuator`) e protege qualquer path sob `/api/` que não esteja na lista. Endpoints futuros sob `/api/v2/`, `/api/internal/` etc. são automaticamente protegidos sem alterar o filtro.
+
+**`AbstractIntegrationTest` — helpers de POST e DELETE autenticados:**
+Adicionados `postAutenticado(url, cookie, jsonBody, responseType)` e `deleteAutenticado(url, cookie)`. Eliminam a necessidade de montar `HttpEntity` com headers duplicados em cada teste.
+
+**`FecharMesIntegrationTest` — autenticação + URLs atualizadas:**
+Todos os 5 testes agora chamam `autenticarComo(1L)` no `@BeforeEach` e usam `postAutenticado`/`getAutenticado` com as novas URLs `/api/v1/funcionarios/**`. O helper privado `requestBodyEntity()` foi removido por redundância. Zero regressões.
+
+---
+
+## Desvios do plano
+
+Nenhum.
+
+---
+
+## Decisões tomadas durante a execução
+
+**`autenticarComo(1L)` em vez de `autenticarComo(12345L)`:** o plano sugeria `12345L` como exemplo, mas `GerarTokenConviteServiceImpl.gerar()` valida a existência do requisitante via FK. A migration V2 só insere id=1 (`Satyan Saita`). Usando id=1, consistente com o padrão já adotado em `PedidosListIntegrationTest` e `AuthFlowIntegrationTest`.
+
+**`requestBodyEntity()` removido:** com `postAutenticado()` disponível na superclasse, o helper privado de `FecharMesIntegrationTest` que montava `HttpEntity` com Content-Type ficou duplicado. Removido — DRY.
+
+**Cleanup de `auth_token` não adicionado:** os testes existentes (`PedidosListIntegrationTest`, `AuthFlowIntegrationTest`) que já usam `autenticarComo(1L)` não limpam `auth_token` em `@AfterEach`. O token gerado é consumido no `exchange` (campo `usado_em` preenchido) — não bloqueia testes subsequentes. Mantido o padrão pré-existente.
+
+---
+
+## Decisões pendentes (esperando humano)
+
+Nenhuma — tarefa fechada.
+
+---
+
+## Próximos passos / observações pro próximo
+
+- O **front** (branch `fix/005-padronizar-api-v1-front` saindo de `develop`) deve atualizar todas as chamadas `/api/funcionarios` → `/api/v1/funcionarios` em `frontend/src/`.
+- Após back + front mergearem: planner desbloqueia **QA-009** (remoção da nota "não escrever 401/403"; Sub-área A deve incluir cenários 401 + URLs corretas).
+- Planner deve adicionar smell de "consistência de prefixo de URL" ao checklist de `docs/roles/reviewer.md` (issue identificada no plano FIX-005).
+- Marcar item "JWT" em `docs/PENDENCIAS-TECNICAS.md` como `~~resolvido~~` após merge.
+
+---
+
+## Padrões e decisões técnicas
+
+**OCP (Open/Closed Principle) em `shouldNotFilter()`:** a lógica anterior baseada em negação (`!path.startsWith("/api/v1/")`) estava "aberta à quebra" — qualquer novo prefixo de API (`/api/v2/`, `/api/internal/`) herdaria o gap silenciosamente. A allowlist explícita fecha esse vetor: novos prefixos são protegidos *por padrão*, não por omissão.
+
+**Arquitetura hexagonal — adapter in/rest isolado do domínio:** a mudança de URL é puramente no adapter de entrada (`adapters/in/rest/folha/FolhaController`, `adapters/in/rest/funcionario/FuncionarioController`). Nenhuma port, use case ou entidade de domínio foi tocada — o contrato interno entre camadas continua idêntico.
+
+**DRY em testes via herança:** `postAutenticado()` e `deleteAutenticado()` vão em `AbstractIntegrationTest` (camada de test infrastructure), não duplicados em cada subclasse. `FecharMesIntegrationTest` herda e usa diretamente. Quando QA-009 criar `ValeIntegrationTest`, `AdiantamentoIntegrationTest` etc., todos herdarão os mesmos helpers sem cópia.
+
+**Consistência de URL como princípio arquitetural (LSP análogo):** controllers REST são "subclasses comportamentais" da API. Se `PedidoController`, `AuthController`, `ResumoController` usam `/api/v1/`, todo controller novo deve seguir o mesmo padrão — um consumidor que assume o prefixo `/api/v1/` não deve ser surpreendido por um `/api/funcionarios/`. O fix restaura esse invariante.
+
+---
+
+## Arquivos criados/modificados
+
+- `adapters/in/rest/folha/FolhaController.java` (modificado: `@RequestMapping` + Javadoc → `/api/v1/funcionarios`)
+- `adapters/in/rest/funcionario/FuncionarioController.java` (modificado: idem)
+- `infra/security/JwtAuthenticationFilter.java` (modificado: `shouldNotFilter()` → allowlist explícita)
+- `integration/AbstractIntegrationTest.java` (modificado: adicionados `postAutenticado()` e `deleteAutenticado()`)
+- `integration/FecharMesIntegrationTest.java` (modificado: auth + URLs + remover `requestBodyEntity()`)
+- `docs/sprints/03-folha-pagamento/status/FIX-005-back-padronizar-api-v1.md` (novo — este arquivo)

--- a/docs/sprints/03-folha-pagamento/status/FIX-005-back-padronizar-api-v1.md
+++ b/docs/sprints/03-folha-pagamento/status/FIX-005-back-padronizar-api-v1.md
@@ -9,8 +9,8 @@ gates:
   build: ok
   lint: na
   testes: ok
-  testes_total: 352
-  testes_novos: 0
+  testes_total: 354
+  testes_novos: 2
   cobertura_pct: na
   branch_convencao: ok
   territorio: ok
@@ -88,4 +88,5 @@ Nenhuma — tarefa fechada.
 - `infra/security/JwtAuthenticationFilter.java` (modificado: `shouldNotFilter()` → allowlist explícita)
 - `integration/AbstractIntegrationTest.java` (modificado: adicionados `postAutenticado()` e `deleteAutenticado()`)
 - `integration/FecharMesIntegrationTest.java` (modificado: auth + URLs + remover `requestBodyEntity()`)
+- `infra/security/JwtAuthenticationFilterTest.java` (modificado: +2 testes — `OPTIONS` e `/actuator/health` na allowlist)
 - `docs/sprints/03-folha-pagamento/status/FIX-005-back-padronizar-api-v1.md` (novo — este arquivo)

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/rest/folha/FolhaController.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/rest/folha/FolhaController.java
@@ -32,12 +32,12 @@ import org.springframework.web.bind.annotation.*;
  *
  * <p>Vales:
  * <ul>
- *   <li>{@code POST /api/funcionarios/{id}/vales} — Cadastrar vale</li>
- *   <li>{@code GET  /api/funcionarios/{id}/vales?mes=YYYY-MM} — Listar vales do mês</li>
+ *   <li>{@code POST /api/v1/funcionarios/{id}/vales} — Cadastrar vale</li>
+ *   <li>{@code GET  /api/v1/funcionarios/{id}/vales?mes=YYYY-MM} — Listar vales do mês</li>
  * </ul>
  */
 @RestController
-@RequestMapping("/api/funcionarios")
+@RequestMapping("/api/v1/funcionarios")
 public class FolhaController {
 
     private final CadastrarValePortIn cadastrarValeUseCase;

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/rest/funcionario/FuncionarioController.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/adapters/in/rest/funcionario/FuncionarioController.java
@@ -20,15 +20,15 @@ import org.springframework.web.bind.annotation.*;
  *
  * <p>Endpoints:
  * <ul>
- *   <li>{@code POST   /api/funcionarios} — Cadastrar funcionário</li>
- *   <li>{@code GET    /api/funcionarios} — Listar ativos</li>
- *   <li>{@code GET    /api/funcionarios/{id}} — Buscar por ID</li>
- *   <li>{@code PUT    /api/funcionarios/{id}} — Atualizar dados</li>
- *   <li>{@code DELETE /api/funcionarios/{id}} — Desativar (soft delete)</li>
+ *   <li>{@code POST   /api/v1/funcionarios} — Cadastrar funcionário</li>
+ *   <li>{@code GET    /api/v1/funcionarios} — Listar ativos</li>
+ *   <li>{@code GET    /api/v1/funcionarios/{id}} — Buscar por ID</li>
+ *   <li>{@code PUT    /api/v1/funcionarios/{id}} — Atualizar dados</li>
+ *   <li>{@code DELETE /api/v1/funcionarios/{id}} — Desativar (soft delete)</li>
  * </ul>
  */
 @RestController
-@RequestMapping("/api/funcionarios")
+@RequestMapping("/api/v1/funcionarios")
 public class FuncionarioController {
 
     private final CadastrarFuncionarioPortIn cadastrarUseCase;

--- a/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/infra/security/JwtAuthenticationFilter.java
+++ b/financas_bot_telegram/src/main/java/br/com/satyan/stering/saita/financasbottelegram/infra/security/JwtAuthenticationFilter.java
@@ -30,14 +30,25 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         this.cookieFactory = cookieFactory;
     }
 
+    /**
+     * Allowlist explícita de paths que dispensam autenticação JWT.
+     *
+     * <p>Lógica positiva em vez de negativa: qualquer path sob {@code /api/} que
+     * não esteja listado aqui <strong>requer JWT válido</strong>. Endpoints futuros
+     * sob {@code /api/v2/}, {@code /api/internal/} etc. são automaticamente
+     * protegidos sem necessidade de atualizar este filtro.
+     */
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
             return true;
         }
         String path = request.getRequestURI();
-        return !path.startsWith("/api/v1/")
-                || path.equals("/api/v1/auth/exchange");
+        // Allowlist de paths públicos — tudo sob /api/ não listado aqui requer JWT
+        return path.equals("/api/v1/auth/exchange")
+                || path.startsWith("/webhook")
+                || path.startsWith("/actuator")
+                || !path.startsWith("/api/");
     }
 
     @Override

--- a/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/infra/security/JwtAuthenticationFilterTest.java
+++ b/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/infra/security/JwtAuthenticationFilterTest.java
@@ -117,6 +117,25 @@ class JwtAuthenticationFilterTest {
     }
 
     @Test
+    void naoDeveAplicarFiltroEmRequestOptions() {
+        // OPTIONS (CORS preflight) deve ser ignorado independente do path
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setMethod("OPTIONS");
+        req.setRequestURI("/api/v1/pedidos");
+
+        assertThat(filter.shouldNotFilter(req)).isTrue();
+    }
+
+    @Test
+    void naoDeveAplicarFiltroEmActuator() {
+        // /actuator/** é path público — usado pelo health check do load balancer
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setRequestURI("/actuator/health");
+
+        assertThat(filter.shouldNotFilter(req)).isTrue();
+    }
+
+    @Test
     void deveRenovarCookieQuandoJwtEstaVencendo() throws Exception {
         MockHttpServletRequest req = reqComCookie("jwt-velho");
         req.setRequestURI("/api/v1/auth/me");

--- a/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/integration/AbstractIntegrationTest.java
+++ b/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/integration/AbstractIntegrationTest.java
@@ -81,4 +81,24 @@ public abstract class AbstractIntegrationTest {
         headers.add(HttpHeaders.COOKIE, cookie);
         return restTemplate.exchange(url, HttpMethod.GET, new HttpEntity<>(headers), responseType);
     }
+
+    protected <T> ResponseEntity<T> postAutenticado(
+            String url, String cookie, String jsonBody, Class<T> responseType) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.COOKIE, cookie);
+        headers.setContentType(org.springframework.http.MediaType.APPLICATION_JSON);
+        return restTemplate.exchange(
+                url, HttpMethod.POST,
+                new HttpEntity<>(jsonBody, headers),
+                responseType);
+    }
+
+    protected ResponseEntity<Void> deleteAutenticado(String url, String cookie) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.COOKIE, cookie);
+        return restTemplate.exchange(
+                url, HttpMethod.DELETE,
+                new HttpEntity<>(headers),
+                Void.class);
+    }
 }

--- a/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/integration/FecharMesIntegrationTest.java
+++ b/financas_bot_telegram/src/test/java/br/com/satyan/stering/saita/financasbottelegram/integration/FecharMesIntegrationTest.java
@@ -14,11 +14,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 /**
- * Testes de integração do endpoint {@code POST /api/funcionarios/{id}/fechamentos}.
+ * Testes de integração do endpoint {@code POST /api/v1/funcionarios/{id}/fechamentos}.
  *
  * <p>Usa MySQL real via Testcontainers (herdado de {@link AbstractIntegrationTest}).
  * Verifica fluxo completo E2E com banco real: criação de Pedido FOLHA, marcação
  * de vales como fechados e idempotência (409 no segundo fechamento do mesmo mês).
+ * Todos os requests usam cookie JWT obtido via {@link #autenticarComo(Long)}.
  */
 class FecharMesIntegrationTest extends AbstractIntegrationTest {
 
@@ -27,6 +28,7 @@ class FecharMesIntegrationTest extends AbstractIntegrationTest {
     private AdiantamentoRepositoryPortOut adiantamentoSpyRepository;
 
     private Long funcionarioId;
+    private String cookie;
 
     @BeforeEach
     void setUp() {
@@ -38,6 +40,8 @@ class FecharMesIntegrationTest extends AbstractIntegrationTest {
         funcionarioId = jdbcTemplate.queryForObject(
                 "SELECT id FROM funcionario WHERE nome = 'Maria Teste' ORDER BY id DESC LIMIT 1",
                 Long.class);
+        // Autenticar com requisitante_id=1 (seeded pela migration V2)
+        cookie = autenticarComo(1L);
     }
 
     @AfterEach
@@ -69,10 +73,9 @@ class FecharMesIntegrationTest extends AbstractIntegrationTest {
                 { "mes": "2026-05", "ajuste": 0.00 }
                 """;
 
-        ResponseEntity<String> resp = restTemplate.postForEntity(
-                "/api/funcionarios/" + funcionarioId + "/fechamentos",
-                requestBodyEntity(requestBody),
-                String.class);
+        ResponseEntity<String> resp = postAutenticado(
+                "/api/v1/funcionarios/" + funcionarioId + "/fechamentos",
+                cookie, requestBody, String.class);
 
         assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(resp.getBody()).contains("PENDENTE");
@@ -99,17 +102,15 @@ class FecharMesIntegrationTest extends AbstractIntegrationTest {
                 """;
 
         // Primeiro fechamento
-        ResponseEntity<String> primeiro = restTemplate.postForEntity(
-                "/api/funcionarios/" + funcionarioId + "/fechamentos",
-                requestBodyEntity(requestBody),
-                String.class);
+        ResponseEntity<String> primeiro = postAutenticado(
+                "/api/v1/funcionarios/" + funcionarioId + "/fechamentos",
+                cookie, requestBody, String.class);
         assertThat(primeiro.getStatusCode()).isEqualTo(HttpStatus.OK);
 
         // Segundo fechamento do mesmo mês → 409
-        ResponseEntity<String> segundo = restTemplate.postForEntity(
-                "/api/funcionarios/" + funcionarioId + "/fechamentos",
-                requestBodyEntity(requestBody),
-                String.class);
+        ResponseEntity<String> segundo = postAutenticado(
+                "/api/v1/funcionarios/" + funcionarioId + "/fechamentos",
+                cookie, requestBody, String.class);
         assertThat(segundo.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
         assertThat(segundo.getBody()).contains("FECHAMENTO_DUPLICADO");
     }
@@ -120,10 +121,9 @@ class FecharMesIntegrationTest extends AbstractIntegrationTest {
                 { "mes": "2026-06", "ajuste": 0.00 }
                 """;
 
-        ResponseEntity<String> resp = restTemplate.postForEntity(
-                "/api/funcionarios/999999/fechamentos",
-                requestBodyEntity(requestBody),
-                String.class);
+        ResponseEntity<String> resp = postAutenticado(
+                "/api/v1/funcionarios/999999/fechamentos",
+                cookie, requestBody, String.class);
 
         assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
     }
@@ -131,18 +131,14 @@ class FecharMesIntegrationTest extends AbstractIntegrationTest {
     @Test
     void deveListarFechamentosAnteriores() {
         // Fecha dois meses diferentes
-        restTemplate.postForEntity(
-                "/api/funcionarios/" + funcionarioId + "/fechamentos",
-                requestBodyEntity("{ \"mes\": \"2026-03\", \"ajuste\": 0.00 }"),
-                String.class);
-        restTemplate.postForEntity(
-                "/api/funcionarios/" + funcionarioId + "/fechamentos",
-                requestBodyEntity("{ \"mes\": \"2026-02\", \"ajuste\": 0.00 }"),
-                String.class);
+        postAutenticado("/api/v1/funcionarios/" + funcionarioId + "/fechamentos",
+                cookie, "{ \"mes\": \"2026-03\", \"ajuste\": 0.00 }", String.class);
+        postAutenticado("/api/v1/funcionarios/" + funcionarioId + "/fechamentos",
+                cookie, "{ \"mes\": \"2026-02\", \"ajuste\": 0.00 }", String.class);
 
-        ResponseEntity<String> resp = restTemplate.getForEntity(
-                "/api/funcionarios/" + funcionarioId + "/fechamentos",
-                String.class);
+        ResponseEntity<String> resp = getAutenticado(
+                "/api/v1/funcionarios/" + funcionarioId + "/fechamentos",
+                cookie, String.class);
 
         assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
         // Março deve aparecer antes de fevereiro (mes_referencia DESC)
@@ -173,10 +169,9 @@ class FecharMesIntegrationTest extends AbstractIntegrationTest {
         doThrow(new RuntimeException("falha simulada no passo 10 — B3"))
                 .when(adiantamentoSpyRepository).save(any());
 
-        ResponseEntity<String> resp = restTemplate.postForEntity(
-                "/api/funcionarios/" + funcionarioId + "/fechamentos",
-                requestBodyEntity("{ \"mes\": \"2026-07\", \"ajuste\": 0.00 }"),
-                String.class);
+        ResponseEntity<String> resp = postAutenticado(
+                "/api/v1/funcionarios/" + funcionarioId + "/fechamentos",
+                cookie, "{ \"mes\": \"2026-07\", \"ajuste\": 0.00 }", String.class);
 
         // Transação deve ter sido revertida → 5xx do servidor
         assertThat(resp.getStatusCode().is5xxServerError()).isTrue();
@@ -190,11 +185,4 @@ class FecharMesIntegrationTest extends AbstractIntegrationTest {
                 .isEqualTo(0);
     }
 
-    // ── Helper ───────────────────────────────────────────────────────────────
-
-    private org.springframework.http.HttpEntity<String> requestBodyEntity(String json) {
-        org.springframework.http.HttpHeaders headers = new org.springframework.http.HttpHeaders();
-        headers.setContentType(org.springframework.http.MediaType.APPLICATION_JSON);
-        return new org.springframework.http.HttpEntity<>(json, headers);
-    }
 }


### PR DESCRIPTION
## Resumo

- `FolhaController` e `FuncionarioController`: `@RequestMapping` de `/api/funcionarios` → `/api/v1/funcionarios` — todos os 11 endpoints de folha/funcionário agora seguem o padrão `/api/v1/` do projeto
- `JwtAuthenticationFilter.shouldNotFilter()`: refatorado de lógica negativa para **allowlist explícita** — qualquer path sob `/api/` não listado explicitamente requer JWT (defesa em profundidade)
- `AbstractIntegrationTest`: adicionados `postAutenticado()` e `deleteAutenticado()` — helpers reutilizáveis para todos os integration tests futuros
- `FecharMesIntegrationTest`: autenticação JWT adicionada + URLs atualizadas — 5 testes usando `postAutenticado`/`getAutenticado` com `/api/v1/funcionarios/**`

## Verificação

- `grep -r "/api/funcionarios" financas_bot_telegram/src/main/` → zero resultados
- `mvn test` ✅ 352 testes, 0 falhas

## Gap corrigido

Os 11 endpoints de folha/funcionário estavam acessíveis sem autenticação. O fix move as URLs para `/api/v1/`, cobrindo-os automaticamente pelo filtro existente, e refatora o filtro para evitar o mesmo gap no futuro.

## Próximo passo

`fix/005-padronizar-api-v1-front` (mesmo FIX, território front) atualiza as chamadas de API no `frontend/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)