### PR TITLE
fix(FIX-008): aceita develop no gate de convenção de branch do CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,25 @@ jobs:
         run: |
           REF="${{ github.head_ref || github.ref_name }}"
           echo "Branch: $REF"
+          # 'develop' e cabeca legitima num caso so: o PR de sincronizacao que o
+          # planner abre de develop para integration/**, para levar plano novo da
+          # sprint ate a branch de onde os implementadores saem.
+          #
+          # Isso NAO afrouxa o gate. Este workflow so dispara em pull_request com
+          # base develop ou integration/** (ver 'on:' no topo), e PR de develop
+          # para develop nao existe -- logo head=develop implica base=integration/**
+          # por construcao. E 'push' nao lista develop, entao github.ref_name nunca
+          # chega aqui valendo develop.
+          #
+          # Nao juntar na regex abaixo: ela descreve FORMATO DE SLUG, e develop e
+          # um caso nomeado com motivo proprio. Sem este comentario, a proxima
+          # pessoa remove a linha por parecer excecao sem razao.
+          if [[ "$REF" == "develop" ]]; then
+            echo "Branch 'develop' aceita (PR de sincronizacao para integration/**)."
+            exit 0
+          fi
           if [[ ! "$REF" =~ ^(feature|fix|hotfix|integration)/[a-z0-9]+(-[a-z0-9.]+)*$ ]]; then
-            echo "::error::Branch '$REF' fora da convenção (feature/<slug>, fix/<slug>, hotfix/<slug>, integration/<slug>)."
+            echo "::error::Branch '$REF' fora da convenção (develop, feature/<slug>, fix/<slug>, hotfix/<slug>, integration/<slug>)."
             exit 1
           fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,8 +145,14 @@ main (protegida — só via PR)
       │    └── feature/fe-014-botao-ver-arquivo-original ← front ┘ implementador abre e aceita
       ├── fix/001-whatsapp-defaults-deploy-safe        ← back → develop direto (padrão zero-padded)
       └── hotfix/NNN-<slug>                            ← emergências → develop direto
+
+ develop ──[PR de sincronização]──▶ integration/<NN>   ← planner, durante a sprint,
+                                                          pra levar plano/ADR novo
+                                                          até quem sai da integration
 ```
 > **PR integration→develop:** Claude (planner) abre ao fim da sprint; humano revisa e aceita. Este é o único gate humano no fluxo de features.
+>
+> **PR develop→integration (sincronização):** Claude (planner) abre **durante** a sprint, sempre que publicar em `develop` um artefato que os implementadores precisam enxergar — plano novo de task, ADR, mudança de template ou de skill. Sem ele a `integration/<NN>` fica parada no último merge de feature, e quem cria a branch a partir dela **não vê o próprio plano da task**. É PR de sync, não de entrega: `develop` sempre contém a integration, então não há divergência nem conflito possível. Pode ser auto-aceito pelo planner.
 
 - Back e front sempre criam branch a partir de `integration/<NN>-<slug>` da sprint (ver "Worktrees git" pro fluxo correto). FIX e HOTFIX saem direto de `develop`.
 - **Padrão de nome de branch:**


### PR DESCRIPTION
Destrava o **PR #125**, que o gate rejeitava com `Branch 'develop' fora da convenção`.

## Causa

`.github/workflows/ci.yml:38` exige prefixo `feature|fix|hotfix|integration`. Em `pull_request`, `github.head_ref` vale `develop` — e o PR de sincronização `develop → integration/**` é caminho legítimo.

**É a segunda ocorrência da mesma classe de falha.** A **FIX-002** foi literalmente `ci-aceitar-integration-no-gate-de-branch`, na mesma linha. O padrão: a allowlist do gate codifica o fluxo de branches, e ninguém a atualiza quando o fluxo ganha caminho novo. Por isso o segundo commit documenta o caminho no `CLAUDE.md` — corrigir só o gate garantiria uma terceira ocorrência.

## Não afrouxa o gate

O workflow só dispara em `pull_request` com base `develop` ou `integration/**`, e PR de `develop` para `develop` não existe. Logo **`head == develop` implica `base == integration/**` por construção**. E `push` não lista `develop`, então `github.ref_name` nunca chega ao check valendo `develop`. A permissão já nasce escopada — sem precisar de condicional sobre a base.

Optei por early-exit em vez de somar `develop` à alternância da regex: a regex descreve *formato de slug*, e `develop` é caso nomeado com motivo próprio. O comentário no arquivo existe para impedir que a próxima pessoa remova a linha por parecer exceção gratuita.

## Verificação

- YAML parseia (`yaml.safe_load`).
- Lógica simulada contra 12 nomes: `develop`, `feature/…`, `fix/…`, `hotfix/…`, `integration/…` aceitos; `main`, `Develop`, `develop-x`, `develop/foo`, `minha-branch`, `feature/` rejeitados.

## Achado não corrigido (de propósito)

A faixa `[a-z0-9]` é **sensível a locale**. Sob `LC_COLLATE=en_US.UTF-8` ela casa maiúscula por ordem de collation e `feature/QA-013` **passa**; sob `C`/`C.UTF-8`, não passa. **Bug pré-existente, não introduzido aqui** — fora do escopo desta FIX, vai para o registro de débitos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)