### PR TITLE
sync: alinha integration/04 com develop (plano QA-014 + consolidação da QA-013)

### DIFF
--- a/docs/PENDENCIAS-TECNICAS.md
+++ b/docs/PENDENCIAS-TECNICAS.md
@@ -590,6 +590,104 @@ Sob collation `en_US`, `[a-z]` casa maiúscula pela ordem de collation, não pel
 
 ---
 
+### `toUpperCase()`/`toLowerCase()` sem `Locale` — 5 ocorrências, 2 com corrupção silenciosa de dado
+
+**Contexto (QA-013, 2026-08-12 — achados do PMD, regra `UseLocaleWithCaseConversions`, com o comportamento sob `tr-TR` medido):** conversão de caixa sem `Locale` usa o locale **default da JVM**. Sob locale turco, `"pix".toUpperCase()` produz `"PİX"` — com `İ` (I com ponto), não `I`. **Nenhum dos casos lança exceção**; todos degradam em silêncio.
+
+| Onde | O que acontece sob `tr-TR` | Gravidade |
+|---|---|---|
+| `LegendaParser:21` | `pix` deixa de casar e é classificado como `OUTRO` **em memória** | real, transitório |
+| `PaymentProofStrategy:81` | **grava `PİX`** em `comprovantes.tipo_pagamento` (`VARCHAR(255)`, sem `CHECK`) | **real e persistente** |
+| `PedidoController:64` | `StatusPedido.valueOf(status.toUpperCase())` — único `Enum.valueOf` assim em produção | hoje inócuo, **por acidente** |
+| `PedidoSpecs:42` | filtro — efeito provável é registro sumir do resultado | **não lido individualmente** |
+| `ResumoMesServiceImpl:38` | agregação — mesmo efeito provável | **não lido individualmente** |
+
+**O caso mais grave é o `PaymentProofStrategy:81`**, e a razão é a persistência: o dado errado **fica no banco depois** de o locale ser corrigido. Os demais se resolvem sozinhos quando o ambiente volta ao normal.
+
+> ⚠️ **Correção de rota do Reviewer (achado `F1`, rodada 1):** a primeira versão do status afirmava que essa linha alimentava `Enum.valueOf` e **derrubava** o processamento da mensagem. É **falso** — o valor trafega e é persistido como `String`, e o rastreamento independente confirmou que não há `Enum.valueOf` nesse fluxo. Corrupção silenciosa, não exceção. Registrado aqui porque o ranqueamento errado quase entrou neste arquivo como incidente de disponibilidade.
+
+**Sobre o `PedidoController:64`:** é inócuo hoje **só porque** nenhum valor de `StatusPedido` (`PENDENTE`, `PAGO`, `CANCELADO`) contém a letra `i` — acidente, não proteção. E `PedidoController:65-67` já captura `IllegalArgumentException` devolvendo 400, então o modo de falha real é **mensagem enganosa**, não indisponibilidade. Não priorizar acima do que vale.
+
+**Fix sugerido:** `Locale.ROOT` em todas as 5. Ler antes as duas de `PedidoSpecs` e `ResumoMesServiceImpl`, que ninguém abriu ainda.
+
+**Esforço:** baixo — 5 linhas. **Prioridade:** **alta** para `PaymentProofStrategy:81` (corrompe dado persistido); média para as demais.
+
+**Nota de método:** nem o PIT nem os testes atuais pegam esses bugs — os testes rodam no locale da máquina. Um teste sob `-Duser.language=tr` pegaria.
+
+---
+
+### `AvoidCatchingGenericException` — 10 ocorrências em produção, 1 em teste
+
+**Contexto (QA-013, baseline do PMD):** é o **maior bloco do baseline** — 11 das 23 violações. Captura de `Exception`/`RuntimeException` genérica engole causa e dificulta diagnóstico.
+
+**Por que importa além do estilo:** é exatamente o modo de falha que o experimento de alocação de modelo quer medir em código gerado por LLM. O baseline alto significa que o sinal do experimento vai competir com ruído pré-existente se a medição não for por diff.
+
+**Fix sugerido:** não corrigir em bloco. Tratar quando o arquivo for tocado por outro motivo.
+
+**Prioridade:** média.
+
+---
+
+### Dois métodos com complexidade alta confirmada por duas métricas independentes
+
+**Contexto (QA-013, medição do PMD):**
+
+| Método | Ciclomática | Outra métrica |
+|---|---:|---|
+| `AtualizarFuncionarioServiceImpl.atualizar` | 12 | **NPath 2048** (threshold 200) |
+| `CadastrarFuncionarioServiceImpl.validarDadosPagamento` | 18 | **Cognitiva 17** |
+
+**Por que os dois casos são diferentes entre si:**
+
+- No primeiro, **NPath 2048** significa 2048 combinações de caminho. Cobertura de caminhos ali é inalcançável na prática — não é meta realista, e vale saber disso antes de alguém tentar.
+- No segundo, ciclomática e cognitiva **concordam** (18 e 17). Quando as duas concordam, não é artefato de contagem: é complexidade real de leitura. A limitação conhecida da ciclomática — não distinguir `switch` largo e legível de aninhamento profundo — não se aplica aqui, justamente porque a cognitiva confirma.
+
+**Fix sugerido:** extração de método, quando houver motivo para tocar nas classes. **Prioridade:** média.
+
+---
+
+### Nenhuma ferramenta do repositório mede conformidade arquitetural
+
+**Contexto (QA-013, desvio 2):** o PMD **não enxerga** violação de arquitetura hexagonal. O débito conhecido de `DataIntegrityViolationException` importada na camada de aplicação (registrado neste arquivo) continua **invisível** para o ferramental, mesmo depois de instalado.
+
+**O ponto que generaliza:** das três ferramentas da sprint 04 — PIT, PMD e (futuro) JaCoCo — **nenhuma** mede conformidade arquitetural. Cobrir exigiria configurar `LoosePackageCoupling` com a lista de pacotes, ou **ArchUnit**.
+
+**Convergência com o item #8 do backlog da sprint:** o gate da convenção `*IntegrationTest` já colocou ArchUnit em cima da mesa, e o argumento a favor dele era exatamente escalar para os outros invariantes que hoje só vivem em prosa no `financas_bot_telegram/CLAUDE.md` — JPA vive no adapter, adapters não se conhecem, nada novo em `usecases/`. **Este débito é a segunda evidência a favor da mesma decisão.**
+
+**Prioridade:** média — sobe se o item #8 escolher ArchUnit.
+
+---
+
+### Testcontainers não alcança o Docker na máquina de desenvolvimento
+
+**Contexto (QA-013, 2026-08-12/13):** 48 testes em 11 classes `*IntegrationTest` falham **localmente** com `Could not find a valid Docker environment` (`NpipeSocketClientProviderStrategy`). Sem container, o contexto cai em H2 sem schema e os testes morrem em `Table "AUTH_TOKEN" not found`.
+
+**Não é código, e isso foi provado por execução:** o CI rodou a suíte completa sobre o mesmo commit e devolveu `Tests run: 422, Failures: 0, Errors: 0` (run `31727999562`). Os testes estão sãos.
+
+**A armadilha:** `docker info` responde normalmente no shell. Isso **não** garante que a JVM do Maven alcança o daemon — foi o que enganou a primeira análise.
+
+**Efeito prático:** quem desenvolver nessa máquina só descobre quebra de integração **no CI**, depois de abrir o PR. E enquanto isso, toda task tende a fechar `parcial` por um gate que não reflete o repositório.
+
+**Fix sugerido:** FIX de ambiente próprio — configurar `DOCKER_HOST`/`TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE` ou trocar a estratégia de descoberta. **Não** consertar de carona em task de feature.
+
+**Prioridade:** **alta** — é o gate de teste local do repositório inteiro.
+
+---
+
+### `SimplifyBooleanReturns` excluída do ruleset por bug de versão, sem gatilho de reavaliação
+
+**Contexto (QA-013 + Reviewer, verificado por experimento controlado):** a regra foi removida do ruleset porque, no **PMD 7.7.0**, a mensagem sai com placeholder não substituído **e com o operador trocado em 2 dos 4 formatos** — sugere `!c || e` onde o correto é `!c && e`. Saída não acionável e que induz a erro é ruído legítimo de remover.
+
+**O problema:** a exclusão é consequência de um **defeito de versão**, não de propriedade permanente da regra. Sem gatilho, vira definitiva por inércia.
+
+**Fix sugerido:** amarrar a reavaliação ao próximo upgrade de PMD — junto com nova curadoria e **hash novo**.
+
+**Mesmo raciocínio vale para `MissingSerialVersionUID`:** 25 ocorrências, todas em `*Exception.java`, deliberadamente fora do ruleset. A justificativa procede hoje; se algum dia este stack serializar exceção, a decisão precisa ser revisitada. O gatilho está no status da QA-013, **não** no XML congelado — e é o XML que sobrevive.
+
+**Prioridade:** baixa.
+
+---
+
 ## Itens resolvidos
 
 ### ~~Esconder `@RequisitanteId` do Swagger UI~~

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -36,10 +36,17 @@
 - **Item 11 do `BACKLOG-evolucao-workflow`** (mudanças em `.claude/`) — commit `105d955`, 2026-08-12. Regra de asserção sobre valor na `writing-java-unit-tests`; consistência rótulo × número na `artifact-report-contract`; campo `mutation_gate` no planner/backend/reviewer e nos dois templates de plano; remoção das referências penduradas a `.github/instructions/`.
   - ⚠️ **Config de agente é carregada no spawn** — isso só vale a partir da próxima sessão.
 
+- **QA-013 — PMD: ruleset curado e piloto de leitura interpretada.** PRs #127 e #128. Reviewer: **aprovado com observações**, 2 rodadas (1 achado `high` derrubado e corrigido; `F6` `low` segue aberto, custo de duas frases). Absorveu o item #5 do backlog.
+  - `maven-pmd-plugin` fora do ciclo de vida + `pmd-ruleset.xml` com **10 regras justificadas uma a uma**. Gate `lint` do backend **deixa de ser `na`** — informativo, não bloqueante.
+  - **Baseline congelado — só vale junto com o hash:** `Q7_producao = 22` · `Q7_teste = 1` · `sha256 = 5100b68f387a0f0d4a8a6d8ba6540c715854709869790373df1118acb71755a9`. **Δ medido contra outro ruleset não é comparável.**
+  - Achado de maior valor: **2 bugs reais de locale**, um deles **gravando dado corrompido no banco** (`PaymentProofStrategy:81`). Ver registro de pendências.
+
 ### 🔵 Próximo a refinar
 
 - **Item #2 do backlog s04 — corrigir os testes fracos revelados pelo piloto.** Alvo concreto já identificado: falta caso com palavra-chave no **índice 0** em `LegendaParser`. Após escrever o teste, rodar o PIT e conferir que a classe sai de 6/8 para 7/8. Os outros dois sobreviventes são equivalentes e **não devem** ser perseguidos.
-- Demais frentes ainda não refinadas: PMD (item #4), JaCoCo (#6), mecanismo de "classes tocadas" (#7), hooks de coleta de custo, pinagem de modelo dos agentes.
+- **Item #6 — piloto do JaCoCo.** É o que **destrava `cobertura_pct`**, hoje `na` em 100% dos status reports. As 4 classes do piloto já têm mutation score e violações medidos; a cobertura fecha o trio sobre o mesmo código.
+- **Item #8 — gate da convenção `*IntegrationTest`.** A QA-013 trouxe **segunda evidência a favor do ArchUnit**: nenhuma das três ferramentas da sprint mede conformidade arquitetural.
+- Demais frentes não refinadas: mecanismo de "classes tocadas" (#7), hooks de coleta de custo, pinagem de modelo dos agentes.
 
 ### Decisão pendente da sprint
 
@@ -78,6 +85,8 @@
 - **`keystore_password` não confirmado em `finbot-prod-secrets`** — se faltar, o próximo recreate da EC2 aborta o bootstrap e a instância fica sem aplicação e sem reverse proxy.
 - **Validação funcional do webhook WhatsApp pós-deploy (FIX-006)** nunca registrada — o deploy verde prova que a app sobe, não que a guarda fail-closed funciona.
 - **QA-010 / QA-011** — gaps de teste de front e de E2E do caminho positivo, herdados da sprint 03.
+- 🔴 **`PaymentProofStrategy:81` grava dado corrompido sob locale não-inglês** — `toUpperCase()` sem `Locale` persiste `PİX` em `comprovantes.tipo_pagamento`. O dado errado **fica no banco depois** de o locale ser corrigido. Mais 4 ocorrências da mesma classe, 2 delas ainda não lidas. Achado da QA-013.
+- **Testcontainers não alcança o Docker na máquina local** — 48 testes de integração falham aqui e passam no CI (`Tests run: 422`, run `31727999562`). **Não é código**, é ambiente: `docker info` responder no shell não garante que a JVM do Maven alcança o daemon. Enquanto não resolver, toda task tende a fechar `parcial` por um gate que não reflete o repositório.
 - **DEP-07:** PR #64 aguarda merge + `terraform apply` (in-place confirmado).
 - **DEP-08:** webhook via Caddy/Let's Encrypt — Fase 2, aguarda ADR de topologia TLS.
 - **BE-20 / PREP-WA fases 4, 8, 9:** bloqueado por chip WhatsApp Business + Business Verification (dependência externa). Popular os 4 secrets em `finbot-prod-secrets` é pré-condição, e há duas guardas de sentinela a remover quando isso acontecer.

--- a/docs/sprints/04-instrumentacao-qualidade/backlog-s04.md
+++ b/docs/sprints/04-instrumentacao-qualidade/backlog-s04.md
@@ -66,6 +66,19 @@ O PIT já reporta as duas. **Decidir se `test strength` vira métrica de primeir
 
 ## 4. PMD — ruleset e escopo, sem Checkstyle
 
+> ✅ **Concluído como [`QA-013`](plans/QA-013-pmd-ruleset-curado-e-piloto.md)** em 2026-08-12 (PRs #127 e #128). **Absorveu o item #5** — a curadoria de ruleset é empírica e não fechava sem o piloto. Reviewer: `aprovado_com_observacoes`, 2 rodadas.
+>
+> **Entregue:** `maven-pmd-plugin` fora do ciclo de vida, `pmd-ruleset.xml` com 10 regras justificadas uma a uma, baseline do legado e leitura interpretada das 8 violações do piloto.
+>
+> **Baseline congelado — só vale junto com o hash:**
+> ```
+> Q7_producao = 22    Q7_teste = 1
+> sha256 = 5100b68f387a0f0d4a8a6d8ba6540c715854709869790373df1118acb71755a9
+> ```
+> **Δ medido contra outro ruleset não é comparável.**
+>
+> O detalhamento abaixo fica como registro da origem. Débitos em [`pendencias-tecnicas.md`](pendencias-tecnicas.md).
+
 **Origem:** `04-metricas.md` Q6 e Q7 · `05-instrumentacao-e-harness.md` §5 (PMD não existe).
 
 **Decidido com o humano em 2026-08-10: instalar apenas PMD, não instalar Checkstyle.**
@@ -89,17 +102,15 @@ O PIT já reporta as duas. **Decidir se `test strength` vira métrica de primeir
 
 ---
 
-## 5. Piloto do PMD — escopo reduzido
+## 5. ~~Piloto do PMD — escopo reduzido~~ — absorvido pelo #4
 
-**Depende de:** #4 (decisão de ruleset).
-
-Aplicar em **conjunto pequeno de classes já existentes**, para o humano ver a ferramenta funcionando antes de decidir escopo definitivo.
-
-**Escopo sugerido:** as mesmas quatro classes do piloto do PIT, mais **uma classe reconhecidamente complexa** para contraste — candidata natural: `FecharMesServiceImpl`, que o `PENDENCIAS-TECNICAS.md` já aponta como tendo acoplamento questionável.
-
-Rodar só nas classes limpas não ensina nada: sem violação, o humano não vê a ferramenta trabalhar. **O contraste é o ponto pedagógico.**
-
-**Entregável:** relatório + leitura interpretada. Para cada violação, classificar em (a) problema real, (b) falso positivo, (c) regra que não queremos. O resultado de (c) alimenta a curadoria do ruleset do item #4.
+> ⬛ **Não vira task própria.** Absorvido pela [`QA-013`](plans/QA-013-pmd-ruleset-curado-e-piloto.md) por decisão do humano em 2026-08-12.
+>
+> **Por que a separação não se sustentava:** a curadoria de ruleset é **empírica** — não se escolhe regra a regra sem ver o que cada uma dispara no código real —, e este item declarava que a classificação "(c) regra que não queremos" alimenta a curadoria do #4. O #4 dependia de um output que só o #5 produzia.
+>
+> **Executado dentro da QA-013:** as 4 classes do piloto do PIT mais `FecharMesServiceImpl` como contraste, com as 8 violações classificadas em (a)/(b)/(c) e justificativa por violação. A curadoria levou **2 rodadas** até o ruleset estabilizar.
+>
+> Resultado da classificação: **2 problemas reais** (bugs de locale), o resto falso positivo ou regra descartada. Os dois `(a)` estão no registro global de pendências.
 
 ---
 
@@ -156,6 +167,25 @@ Runs diferentes tocam conjuntos diferentes de classes, logo têm denominadores d
 Portanto: **Q3, Q6 e Q7 só são interpretados junto com Q4** (critérios de aceitação satisfeitos) **e Q5** (tamanho do diff). Run que falha Q4 sai da comparação de qualidade ou entra sinalizado.
 
 **Ação:** emendar no `04-metricas.md` e incluir no pré-registro — **não como nota de rodapé no artigo**.
+
+### Premissas medidas pelos pilotos — ler antes de estimar
+
+Três fatos que os pilotos do PIT e do PMD produziram e que **mudam o desenho deste item**:
+
+1. **O piso de custo do PIT é a suíte unitária inteira, não o tamanho de `targetClasses`** (QA-012). A fase de cobertura roda as 70 classes de teste uma vez antes de mutar qualquer coisa — 22s dos 48s do piloto. **Restringir `targetClasses` reduz a fase de mutação, não a de cobertura.** Mitigação a avaliar: `targetTests` explícito, e/ou `historyInputLocation`.
+
+2. **Regras sensíveis a resolução de tipo mudam de resultado com o estado do build** (QA-013, medido pelo Reviewer). `LawOfDemeter` deu **2** violações sem `target/classes` e **26** com. O ruleset congelado é **insensível** — 22 nos dois casos, verificado —, mas isso é propriedade deste ruleset, não do PMD. **O Δ precisa fixar e declarar se mede com o projeto compilado.**
+
+3. **`-Dpmd.rulesets` não existe** (QA-013). Trocar de ruleset exige editar o `pom.xml` — não é flag de linha de comando, e a edição muda o hash. O Reviewer precisou montar projetos-cópia para reproduzir números com ruleset diferente.
+
+**Baseline já congelado, disponível para o Δ:**
+
+```
+Q7_producao = 22    Q7_teste = 1
+sha256(pmd-ruleset.xml) = 5100b68f387a0f0d4a8a6d8ba6540c715854709869790373df1118acb71755a9
+```
+
+⚠️ **Não silenciar violação com `@SuppressWarnings("PMD…")`** — supressão espalhada pelo código torna o `Q7` incomparável entre runs **sem deixar rastro no hash**.
 
 ### Entrega
 

--- a/docs/sprints/04-instrumentacao-qualidade/pendencias-tecnicas.md
+++ b/docs/sprints/04-instrumentacao-qualidade/pendencias-tecnicas.md
@@ -1,0 +1,92 @@
+# Pendências técnicas — Sprint 04 (instrumentação e qualidade)
+
+> **Registro de sprint.** Débitos levantados pelas tasks desta sprint, consolidados pelo planner a partir dos status reports e das avaliações do Reviewer.
+>
+> **Consolidação lida até:** `QA-012` (status + avaliação) e `QA-013` (status + avaliação, 2 rodadas). Próxima consolidação começa da QA-014.
+>
+> **O que fica aqui e o que vai para o global:** débito de **código ou de repositório** — que sobrevive ao fim da sprint — é promovido para [`../../PENDENCIAS-TECNICAS.md`](../../PENDENCIAS-TECNICAS.md) e aqui fica só o ponteiro. O que é **metodológico ou específico do ferramental desta sprint** fica aqui.
+
+---
+
+## Promovidos ao registro global
+
+Ver [`docs/PENDENCIAS-TECNICAS.md`](../../PENDENCIAS-TECNICAS.md):
+
+| Débito | Origem | Prioridade |
+|---|---|---|
+| `toUpperCase()`/`toLowerCase()` sem `Locale` — 5 ocorrências, **2 com bug real de corrupção silenciosa** | QA-013 débitos 1, 1b, 2 | **alta** |
+| `AvoidCatchingGenericException` — 10 em produção + 1 em teste | QA-013 débito 3 | média |
+| Dois métodos com complexidade alta confirmada por duas métricas | QA-013 débitos 4, 5 | média |
+| Nenhuma ferramenta do repo mede conformidade arquitetural | QA-013 débito 6 | média |
+| `MissingSerialVersionUID` — 25 ocorrências fora do ruleset por decisão | QA-013 débito 7 | baixa |
+| Testcontainers não alcança o Docker na máquina de desenvolvimento | QA-013 débito 8 | **alta** |
+| `SimplifyBooleanReturns` excluída por bug de versão do PMD 7.7.0 | Reviewer QA-013 | baixa |
+| Convenção `*IntegrationTest` não é verificada por nada | QA-012 débito 3 | alta |
+| Piso de custo do PIT é a suíte inteira | QA-012 débito 7 | média |
+| PIT sem histórico incremental; medido em JVM diferente da do CI | QA-012 débitos 4, 5 | baixa |
+| Repo não tem infraestrutura de captura de log em teste | QA-012 débito 2 | baixa |
+
+---
+
+## Itens metodológicos — ficam nesta sprint
+
+### Premissa obrigatória do item #7: regras sensíveis a resolução de tipo mudam com o estado do build
+
+**Origem:** Reviewer da QA-013, achado `F4`, **medido**.
+
+O item #7 do backlog vai calcular **Δ de violações** entre a tag do marco zero e o `HEAD`. Isso pressupõe que o número de violações depende só do código — e **não depende**: regras que fazem resolução de tipo consultam o `auxclasspath`, então o resultado muda conforme `target/classes` esteja populado.
+
+Medição do Reviewer com `LawOfDemeter`:
+
+| `target/classes` | Violações |
+|---|---:|
+| vazio | **2** |
+| populado | **26** |
+
+**O ruleset congelado é insensível a isso** — verificado: 22 violações nos dois casos. Mas a insensibilidade é propriedade **deste** ruleset, não do PMD.
+
+**Consequência para quem desenhar o #7:** fixar e **declarar** se a medição roda com o projeto compilado. Se uma curadoria futura incluir regra sensível a tipo, um Δ medido com build sujo é ruído puro.
+
+---
+
+### `-Dpmd.rulesets` não existe: trocar de ruleset exige editar o `pom.xml`
+
+**Origem:** QA-013, §Próximos passos.
+
+O `maven-pmd-plugin` não expõe user property para `rulesets`. O `-Dpmd.includeTests` só funciona porque a task adicionou a property no `pom.xml`.
+
+**Impacto no item #7:** medir com ruleset alternativo — para comparação metodológica, por exemplo — não é uma flag de linha de comando; é edição de arquivo versionado, que muda o hash. O Reviewer bateu nisso durante a revisão e teve que montar projetos-cópia para reproduzir os números.
+
+---
+
+### Baseline e hash só valem juntos
+
+**Origem:** QA-013, §Ruleset congelado.
+
+```
+Q7_producao = 22    Q7_teste = 1
+sha256(pmd-ruleset.xml) = 5100b68f387a0f0d4a8a6d8ba6540c715854709869790373df1118acb71755a9
+```
+
+**Δ medido contra outro ruleset não é comparável.** O hash mudou uma vez durante a revisão (correção do comentário após o achado `F1`); o valor acima é o que vale. Qualquer alteração no XML exige nova curadoria, hash novo e registro de a partir de quando a medição nova passa a valer.
+
+**Regra que acompanha:** não silenciar violação com `@SuppressWarnings("PMD…")`. Supressão espalhada pelo código torna o `Q7` incomparável entre runs **sem deixar rastro no hash** — o ruleset continuaria idêntico enquanto a medição muda.
+
+---
+
+### `F6` do Reviewer: duas frases do status divergem do XML e do runbook já corrigidos
+
+**Origem:** Reviewer da QA-013, rodada 2. Severidade **low**, **aberto**.
+
+Nenhuma das duas é falsa no próprio contexto; as duas são resíduo do fix do `F1`, e as duas ficam no **status**, que é o artefato que o planner lê.
+
+1. Item 6–7 da leitura interpretada mantém *"regra cuja remediação está errada"*, formulação que o `F2` pediu para trocar e que **já foi trocada no XML**. A tabela §Revisão independente do mesmo documento declara esse ponto como "Ajustado" — o documento se contradiz a 140 linhas de distância.
+2. §Próximos passos mantém *"não precisa de suíte verde **nem de build**"*; o runbook já ganhou a ressalva do `F4`.
+
+**Custo de fechar:** duas frases. **Não bloqueia nada** — o artefato congelado (XML) e o operacional (runbook) estão corretos, e o baseline não depende de nenhuma das duas. Fica registrado para não sumir; pode ser fechado de carona no próximo commit que tocar o arquivo.
+
+---
+
+### Encerrado nesta sprint
+
+- ~~**Gate `testes` vermelho por Docker indisponível — causa desconhecida.**~~ ✅ **Respondido em 2026-08-13.** O CI rodou a suíte completa no runner (`Tests run: 422, Failures: 0, Errors: 0`, run `31727999562`) sobre o mesmo commit. **A causa é a máquina local, não o repositório** — os `*IntegrationTest` estão sãos. O que sobra é o débito de ambiente, promovido ao registro global.

--- a/docs/sprints/04-instrumentacao-qualidade/plans/QA-014-piloto-jacoco-cobertura.md
+++ b/docs/sprints/04-instrumentacao-qualidade/plans/QA-014-piloto-jacoco-cobertura.md
@@ -1,0 +1,209 @@
+---
+task: QA-014
+titulo: "Piloto do JaCoCo — cobertura medida e comparada com PIT e PMD"
+sprint: 04-instrumentacao-qualidade
+data_planejamento: 2026-08-13
+branch_alvo: feature/qa-014-piloto-jacoco-cobertura
+prioridade: alta
+esforco: medio
+territorio: back
+estado: pronto-pra-execucao
+depende_de: []
+bloqueia: []
+skills_dispatched: []
+integration_branch: integration/04-instrumentacao-qualidade
+fluxos_qa: []
+mutation_gate: false
+mutation_rationale: ""
+---
+
+# QA-014 — Piloto do JaCoCo: cobertura medida e comparada com PIT e PMD
+
+## Intake
+
+- **Origem:** item **#6** de `docs/sprints/04-instrumentacao-qualidade/backlog-s04.md`. Origem primária: `04-metricas.md` **Q2** (cobertura nas classes tocadas) do experimento.
+- **Por quê agora:** é a **terceira e última** ferramenta de qualidade da sprint (PIT ✅ QA-012, PMD ✅ QA-013). Fechando-a, as três descrevem o mesmo código e a comparação entre elas fica possível. É também o que **destrava `cobertura_pct`**, hoje `na` em 100% dos status reports.
+- **Esforço:** médio. A instalação é pequena; o custo está em duas coisas que não são óbvias — neutralizar a distorção do Lombok antes de congelar o baseline, e explicar as divergências entre três medições do mesmo código.
+- **Riscos resumidos:** JaCoCo, ao contrário de PIT e PMD, **precisa dos testes executando** — e nesta máquina os `*IntegrationTest` falham por Docker. Mitigado medindo só a suíte unitária, o que também é o que torna o número comparável com o PIT. O segundo risco é silencioso: Lombok sem configuração infla o código "não coberto".
+
+---
+
+## Contexto
+
+**O que já existe:**
+
+- `financas_bot_telegram/pom.xml` — Java 21, Spring Boot parent. Tem `pitest-maven` 1.25.9 (QA-012) e `maven-pmd-plugin` 3.26.0 (QA-013), ambos **fora do ciclo de vida**. **Não tem JaCoCo.**
+- **191 classes de produção**, **82 de teste**, `testes_total: 422`.
+- **Nenhum `argLine` de surefire configurado** e nenhum bloco `<plugin>` de surefire no `pom.xml` — verificado. Isso importa: o `jacoco:prepare-agent` funciona **injetando `argLine`**, e um `argLine` pré-existente sem `@{argLine}` o sobrescreveria em silêncio, zerando a cobertura sem erro nenhum.
+- **Lombok 1.18.32**, usado em **23 arquivos de produção**, e **não existe `lombok.config`** — verificado por `find`. Ver §Decisão.
+
+**Números já medidos, que esta task vai comparar** (QA-012, passada de cobertura do próprio PIT, restrita às classes mutadas):
+
+| Classe | Line coverage (PIT) | Mutation score | Test strength |
+|---|---:|---:|---:|
+| `LegendaParser` | 94% (17/18) | **75%** | 75% |
+| `PaymentRequestStrategy` | 96% (47/49) | 100% | 100% |
+| `PaymentProofStrategy` | 100% (33/33) | 100% | 100% |
+| `MetaSignatureValidator` | 90% (26/29) | 79% | 85% |
+
+**Correção de um fato que o backlog registra errado.** O item #6 diz que *"o comando `jacoco:report` que o agente QA é instruído a rodar falha hoje"*. Verificado por `grep -rn "jacoco"` em `.claude/`, `docs/templates/` e `docs/runbooks/`: existe **uma única ocorrência no repositório**, um comentário no frontmatter de `docs/templates/_TEMPLATE-status.md:16`. O agente `qa-test-specialist` **não menciona JaCoCo**. Não há comando falhando — há um campo cujo template aponta uma ferramenta que nunca existiu. O efeito é o mesmo (`cobertura_pct: na` sempre), a causa é outra.
+
+**Estado do ambiente:** 48 testes em 11 classes `*IntegrationTest` falham **localmente** por Docker inacessível ao Testcontainers. O CI roda a mesma suíte verde (`Tests run: 422, Failures: 0, Errors: 0`, run `31727999562`). É débito registrado, **não** é escopo desta task.
+
+---
+
+## Decisão / abordagem
+
+### Medir só a suíte unitária — e por quê isso não é atalho
+
+Aplicar a **mesma exclusão `*IntegrationTest`** que o PIT já usa. Três razões, em ordem de importância:
+
+1. **Comparabilidade.** O PIT excluiu essas classes. Se o JaCoCo as incluísse, cobertura e mutation score descreveriam populações diferentes, e toda comparação desta task viraria ruído.
+2. **Qualidade de teste é o que o experimento mede.** Cobertura vinda de teste de integração infla o número sem dizer nada sobre a qualidade dos testes — que é o sinal que o experimento persegue em código gerado por modelo.
+3. **Contorna o Docker por completo**, sem a task ficar refém do FIX de ambiente.
+
+**O custo, que precisa estar escrito no relatório:** o número **subestima** a cobertura real do projeto. Quem comparar com número de mercado tem que saber disso. A frase não é ressalva de rodapé — é parte da definição da métrica.
+
+### Neutralizar o Lombok antes de congelar o baseline
+
+Sem `lombok.config`, o JaCoCo conta **getter, setter, `equals`, `hashCode`, `toString` e builder gerados** como linhas não cobertas. O resultado é um baseline que mede a quantidade de Lombok no projeto, não a qualidade dos testes.
+
+O impacto aqui é assimétrico e foi medido:
+
+- **As 5 classes do piloto têm zero Lombok** — a leitura interpretada sai limpa de qualquer jeito.
+- **O baseline do projeto é distorcido**, porque Lombok se concentra exatamente onde ele gera mais código: `application/dto` (9 arquivos), `adapters/out` (7), `domain/model` (5), `domain/entity` (2).
+
+**Decisão:** criar `financas_bot_telegram/lombok.config` com `lombok.addLombokGeneratedAnnotation = true`. Isso faz o Lombok anotar o que gera com `@lombok.Generated`, que o JaCoCo **honra e exclui** por padrão. É uma linha, é prática padrão, e sem ela o baseline não significa nada.
+
+**Isso é medição, não conserto** — nenhum teste é escrito, nenhuma classe muda. Para provar o tamanho da distorção, o relatório traz **os dois números**, antes e depois. Custa um run a mais e mostra concretamente quanto o Lombok estava mentindo.
+
+### Fora do ciclo de vida, como as outras duas
+
+`jacoco:prepare-agent` **não precisa** de `<executions>`: invocado na mesma linha de comando, ele define o `argLine` que o surefire consome em seguida. Ou seja, dá para manter o mesmo padrão de PIT e PMD — plugin declarado, versão em `<properties>`, **nada amarrado a fase de build**.
+
+Isso preserva a propriedade que a sprint vem mantendo: **nenhuma ferramenta de diagnóstico encarece o build de todo mundo.**
+
+### Sem gate
+
+Nada de `jacoco:check` com threshold. Build que falha por cobertura faz o agente escrever teste **para a métrica**, não para o comportamento — interferência direta na variável medida. Relatório sim, gate não. Mesma decisão do PMD, mesmo motivo.
+
+### Regra provisória para `cobertura_pct`
+
+O campo hoje diz "cobertura % da classe/componente principal", e "principal" é julgamento de quem escreve. Passa a ser: **cobertura de linha das classes de produção que a task tocou**; `na` quando a task não toca classe de produção.
+
+Alinha com o **D3 do item #7** (`Q2` = produção, não teste). É **provisória** até o #7 automatizar o recorte de "classes tocadas", e o plano declara isso para ninguém tratar como definitiva.
+
+### Conjunto do piloto: as 5 classes do PMD
+
+`LegendaParser`, `PaymentRequestStrategy`, `PaymentProofStrategy`, `MetaSignatureValidator` e `FecharMesServiceImpl`.
+
+As 4 primeiras passam a ter **as três ferramentas medindo o mesmo código**. A quinta tem PMD e JaCoCo, e é a mais complexa das cinco — é onde cobertura de **branch** tende a divergir mais de cobertura de linha.
+
+---
+
+## Escopo / arquivos
+
+### Criar
+
+- `financas_bot_telegram/lombok.config` — `lombok.addLombokGeneratedAnnotation = true`, com comentário explicando que existe para o JaCoCo não contar código gerado. Sem o comentário, é a linha mais fácil de alguém apagar sem saber o que quebra.
+
+### Modificar
+
+- `financas_bot_telegram/pom.xml` — `jacoco-maven-plugin`, versão em `<properties>`, **fora do ciclo de vida**, com comentário explicando por que não está amarrado a `test`.
+- `docs/runbooks/ROTEIRO-TESTES-BACKEND.md` — nova subseção na **Camada 1**, no formato da 1.5 (PIT) e da 2.0 (PMD): comando, onde sai o relatório, como ler, e a ressalva de que o número é unit-only.
+- `docs/templates/_TEMPLATE-status.md` — comentário do `cobertura_pct` passa a descrever a regra provisória e o comando real.
+- `docs/runbooks/PRE-MERGE-CHECKLIST.md` — `cobertura_pct` ganha a mesma definição, declarada **informativa, não bloqueante**.
+
+### Não tocar (escopo limitado)
+
+- **Qualquer classe de produção ou de teste.** Nenhum teste novo, nenhum gap de cobertura corrigido. Se o relatório revelar buraco relevante, **vira pendência técnica**.
+- **Configuração de PIT e PMD** no `pom.xml` — blocos vizinhos.
+- **`.github/workflows/`** — JaCoCo não entra no CI nesta task.
+- **O problema de Docker/Testcontainers** — débito próprio, FIX próprio.
+
+---
+
+## Testes
+
+**Não aplicável no sentido usual:** a task não adiciona nem altera lógica de produção. `testes_total` deve permanecer **422** e `testes_novos` deve ser **0**.
+
+⚠️ **Atenção ao registrar o gate `testes`:** o run desta task é **unit-only**, então o número de testes executados será **menor que 422**. Isso **não** é regressão — é o recorte da medição. O relatório precisa registrar quantos testes rodaram no recorte e deixar claro que os 422 continuam válidos na suíte completa (evidência: CI, run `31727999562`).
+
+---
+
+## Critérios de aceitação
+
+- [ ] `jacoco-maven-plugin` no `pom.xml`, versão em `<properties>`, **não amarrado a nenhuma fase do build**.
+- [ ] `financas_bot_telegram/lombok.config` criado com `lombok.addLombokGeneratedAnnotation = true` e comentário explicando o porquê.
+- [ ] Comando documentado roda limpo **sem depender de Docker** e gera relatório HTML + XML.
+- [ ] **Distorção do Lombok quantificada:** cobertura do projeto **antes** e **depois** do `lombok.config`, com a diferença comentada em uma frase.
+- [ ] **Baseline registrado:** cobertura de **linha e de branch** do projeto (produção; teste não entra — o JaCoCo instrumenta só `src/main`), mais o número de testes executados no recorte unit-only.
+- [ ] **Tabela por classe** das 5 classes do piloto: cobertura de linha e de branch.
+- [ ] **Comparação de três números** nas 4 classes com dado do PIT — cobertura de linha do JaCoCo × cobertura de linha do PIT × mutation score — com **cada divergência explicada**. Divergência entre JaCoCo e PIT no mesmo arquivo é o achado mais instrutivo possível aqui: são duas ferramentas contando a mesma coisa de formas diferentes.
+- [ ] **Critério de aprendizado:** o relatório explica, com dado deste projeto, **por que cobertura alta não implica teste bom** — e usa `LegendaParser` (94% de linha no PIT, 75% de mutation score) como caso concreto, agora com o número independente do JaCoCo ao lado.
+- [ ] **Cobertura de branch × de linha:** identificar ao menos uma classe onde as duas divergem de forma relevante e explicar o que a de branch enxerga que a de linha não. `FecharMesServiceImpl` é a candidata natural.
+- [ ] `ROTEIRO-TESTES-BACKEND.md`, `_TEMPLATE-status.md` e `PRE-MERGE-CHECKLIST.md` atualizados com o comando e a regra provisória de `cobertura_pct`.
+- [ ] A limitação **unit-only** está escrita no relatório e no runbook — o número **subestima** a cobertura real.
+- [ ] `testes_novos = 0` e nenhuma classe de produção ou teste alterada.
+- [ ] Branch `feature/qa-014-piloto-jacoco-cobertura` a partir de `integration/04-instrumentacao-qualidade`.
+- [ ] Status report em `docs/sprints/04-instrumentacao-qualidade/status/QA-014-piloto-jacoco-cobertura.md`.
+
+---
+
+## Fora de escopo (explicitamente)
+
+| Item | Onde vive |
+|---|---|
+| Escrever teste para corrigir gap de cobertura | pendência técnica; item #2 para o caso do `LegendaParser` |
+| `jacoco:check` / threshold bloqueante | depois do experimento |
+| JaCoCo no CI | idem |
+| Cobertura da suíte de integração | requer o FIX de Docker; declarar como não medido |
+| FIX do Docker/Testcontainers | débito próprio, FIX próprio |
+| Escopo por diff | item **#7** |
+| Corrigir os 2 bugs de locale da QA-013 | pendência técnica já registrada |
+
+---
+
+## Riscos & mitigações
+
+| Risco | Prob. | Impacto | Mitigação |
+|---|---|---|---|
+| **`argLine` do surefire sobrescrever o do JaCoCo** — cobertura sai **zero sem erro nenhum** | Baixa | **Alto** | Verificado que hoje não há `argLine` nem plugin surefire configurado. Critério de sanidade: se a cobertura vier 0%, é isto — não é falta de teste. Registrar no runbook que qualquer `argLine` futuro precisa de `@{argLine}` |
+| Lombok distorcer o baseline sem ninguém notar | **Alta** sem o `lombok.config` | Alto | `lombok.config` é critério de aceitação, e a distorção é quantificada com os dois números |
+| Docker indisponível bloquear a task | **Alta** se tentar suíte completa | Alto | Recorte unit-only é a decisão central do plano, não contorno improvisado |
+| Confundir "menos testes executados" com regressão | Média | Médio | Explicitado em §Testes: o recorte reduz o número, os 422 seguem válidos com evidência de CI |
+| JaCoCo e PIT divergirem e a divergência ser varrida para baixo do tapete | Média | Médio | Explicar cada divergência é **critério de aceitação**, não opcional |
+| Task extrapolar e escrever teste | Média | Alto | `testes_novos = 0` verificável no diff |
+
+---
+
+## Coordenação
+
+- **Pode rodar em paralelo com:** item #8 (gate `*IntegrationTest`). ⚠️ **Não** rodar em paralelo com o item **#2** (corrigir testes fracos do `LegendaParser`): o #2 muda a cobertura da classe que é o caso central da comparação desta task. Se ambos forem despachados, **esta vai primeiro** — o baseline precisa ser tirado antes.
+- **Depende sequencialmente de:** nada. QA-012 e QA-013 já estão em `develop` e fornecem os números de comparação.
+- **Bloqueia:** item **#7** (o Q2 precisa de JaCoCo instalado) e o pré-registro do experimento.
+- **Atenção pro Reviewer:**
+  - **Conferir que a cobertura não veio zero por `argLine`.** É o modo de falha silencioso desta ferramenta: número plausível de 0% parece "sem teste", quando é instrumentação quebrada.
+  - Conferir que os dois números do Lombok foram medidos de verdade, e não estimados.
+  - **A comparação de três números é o entregável.** Tabela sem explicação de divergência não cumpre o critério — mesmo padrão da QA-013, onde o entregável era a justificativa, não o relatório.
+  - QA-012 teve 5 achados de prosa e QA-013 teve 1 `high` de afirmação não sustentada pela evidência. Esta task produz **três medições do mesmo código**, o que multiplica a chance de rótulo contradizer número. **Todo rótulo qualitativo tem que bater com o dado ao lado.**
+  - Reproduzir o run e conferir o baseline.
+- **Atenção pro QA:** `fluxos_qa: []` — não altera comportamento de produto. **`qa_required: false`.**
+- **Após merge:** fechar o item **#6** no `backlog-s04.md`; registrar o baseline de cobertura no `STATE.md` junto do baseline do PMD; abrir pendência para cada gap relevante encontrado; avaliar se o item **#2** ganha alvo novo.
+
+---
+
+## Definição de pronto
+
+Gates do `docs/runbooks/PRE-MERGE-CHECKLIST.md`, status report válido conforme `_TEMPLATE-status.md`, e **revisão do Reviewer** (sessão separada — ADR 0005). `fluxos_qa: []`, logo **sem gate de QA**. `mutation_gate: false`, logo **sem gate de mutação** — a task não altera código Java de produção, não há classe alterada para entrar no denominador. Implementador abre o PR da feature para `integration/04-instrumentacao-qualidade`; **não** abre PR direto para `develop`.
+
+---
+
+## Referências
+
+- `docs/sprints/04-instrumentacao-qualidade/backlog-s04.md` — item **#6** (este), **#7** (D3/D4 e premissas medidas), **#2** (conflito de ordem).
+- `docs/sprints/04-instrumentacao-qualidade/status/QA-012-piloto-pit-mutation-testing.md` §"Baseline por classe" — os números do PIT que esta task compara.
+- `docs/sprints/04-instrumentacao-qualidade/status/QA-013-pmd-ruleset-curado-e-piloto.md` — padrão de relatório com leitura interpretada e baseline congelado.
+- `docs/sprints/04-instrumentacao-qualidade/pendencias-tecnicas.md` — débito do Docker/Testcontainers e premissas do item #7.
+- `docs/runbooks/ROTEIRO-TESTES-BACKEND.md` §"Camada 1.5 (PIT)" e §"2.0 (PMD)" — formato a replicar.
+- `financas_bot_telegram/pom.xml` — `pitest-maven` e `maven-pmd-plugin` como referência de plugin fora do ciclo de vida.


### PR DESCRIPTION
Sincroniza `integration/04-instrumentacao-qualidade` com `develop`, conforme o fluxo documentado no `CLAUDE.md` §Fluxo de branches ("PR develop→integration (sincronização)").

**Por que importa:** o implementador cria a feature branch a partir de `integration/04`. Sem este sync, quem pegar a **QA-014** não enxerga o próprio plano da task.

Sem divergência — `develop` contém tudo que a integration tem. Merge é sync puro.

## O que entra

| Commit | O quê |
|---|---|
| `e90a45d` | **plano da QA-014** — piloto do JaCoCo com comparação entre as três ferramentas |
| `5e43e79` | consolidação de débitos da QA-013, fechamento do item #4 do backlog e baseline do PMD |
| `70eee9a` | merge do PR #128 |

## Contexto para quem for pegar a QA-014

- **Não pode rodar em paralelo com o item #2** do backlog (corrigir testes fracos do `LegendaParser`): o #2 altera a cobertura da classe usada como caso central da comparação. Esta task vai primeiro.
- O plano exige criar `lombok.config` **antes** de congelar o baseline — sem ele o JaCoCo conta código gerado pelo Lombok como não coberto e o número não significa nada.
- Medição é **unit-only**, com a mesma exclusão `*IntegrationTest` do PIT. O número subestima a cobertura real, e isso é parte da definição da métrica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)